### PR TITLE
CI submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,23 @@ on: [push, pull_request]
 #  workflow_dispatch:
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Setup SSH key
+        uses: webfactory/ssh-agent@v0.6.0
+        with:
+          ssh-private-key: ${{ secrets.DXTB_SSH_PRIVATE_KEY }}
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2


### PR DESCRIPTION
- access to private `dxtb` repository (via SSH key as described [here](https://stackoverflow.com/questions/57612428/cloning-private-github-repository-within-organisation-in-actions/70283191#70283191))
- add checkout of submodules