### PR TITLE
Minor fixes for the mixers and their tests

### DIFF
--- a/tbmalt/common/maths/mixers.py
+++ b/tbmalt/common/maths/mixers.py
@@ -128,7 +128,7 @@ class _Mixer(ABC):
         assert self._delta is not None, 'Nothing has been mixed'
 
         if not self._is_batch:  # If not in batch mode
-            return torch.tensor(self._delta.abs().max() < self.tolerance)
+            return self._delta.abs().max() < self.tolerance
         else:  # If operating in batch mode
             if self._delta.dim() == 1:
                 # Catch needed when operating on a batch of scalars.
@@ -296,7 +296,7 @@ class Simple(_Mixer):
         self._x_old = x_mix
 
         # Update the delta
-        self._delta = (x_mix - x_old)
+        self._delta = (x_new - x_old)
 
         # Return the newly mixed system
         return x_mix
@@ -350,8 +350,8 @@ class Simple(_Mixer):
 class Anderson(_Mixer):
     """Accelerated Anderson mixing algorithm.
 
-    Anderson acceleration, also known as Pulay mixing & DIIS, is a method for
-    accelerating convergence. Upon instantiation a callable instance will be
+    Anderson acceleration is a method for accelerating convergence of fixed
+    point iterations. Upon instantiation, a callable instance will be
     returned. Calls to this instance will take, as its arguments, two input
     systems and will return a single mixed system.
 
@@ -367,10 +367,14 @@ class Anderson(_Mixer):
             to `None` then rescaling will be disabled. [DEFAULT=0.01]
         init_mix_param: Mixing parameter to use during the initial simple
             mixing steps. [DEFAULT=0.01]
+        soft_start: If enabled, then simple mixing will be used for the first
+            ``generations`` number of steps, otherwise only for the first.
+            [DEFAULT=False]
 
     Notes:
-        Note that simple mixing will be used for the first ``generations``
-        number of steps
+        Note that simple mixing will always be used for the first step. If
+        ``soft_start`` is enabled then the simple mixer will also be used for
+        the following ``generations``-1 steps.
 
         The Anderson mixing functions primarily follow the equations set out
         by Eyert [Eyert]_. However, this code borrows heavily from the DFTB+
@@ -399,8 +403,9 @@ class Anderson(_Mixer):
 
     """
     def __init__(self, is_batch: bool, mix_param: Real = 0.05,
-                 generations: int = 6, diagonal_offset=0.01,
-                 init_mix_param: Real = 0.01, tolerance: Real = 1E-6):
+                 generations: int = 4, diagonal_offset=0.01,
+                 init_mix_param: Real = 0.01, tolerance: Real = 1E-6,
+                 soft_start: bool = False):
 
         super().__init__(is_batch, tolerance)
 
@@ -408,6 +413,7 @@ class Anderson(_Mixer):
         self.generations = generations
         self.init_mix_param = init_mix_param
         self.diagonal_offset = diagonal_offset
+        self.soft_start = soft_start
 
         # Holds "x" history and "x" delta history
         self._x_hist: Optional[Tensor] = None
@@ -437,6 +443,7 @@ class Anderson(_Mixer):
             self._shape_in = list(torch.flatten(x_new).shape)
 
         # Instantiate the x history (x_hist) and the delta history 'd_hist'
+        # The current step is also stored hence "self.generations + 1".
         size = (self.generations + 1, *self._shape_in)
         self._x_hist = torch.zeros(size, dtype=dtype, device=device)
         self._f = torch.zeros(size, dtype=dtype, device=device)
@@ -491,13 +498,17 @@ class Anderson(_Mixer):
         self._f[0] = x_new - x_old
 
         # If a sufficient history has been built up then use Anderson mixing
-        if self._step_number > self.generations:
+        # if self._step_number > self.generations:
+        if (self._step_number > self.generations
+                or self.step_number > 1 and not self.soft_start):
+
+            n = min(self.step_number-1, self.generations)
             # Setup and solve the linear equation system, as described in
             # equation 4.3 (Eyert), to get the coefficients "thetas":
             #   a(i,j) =  <F(l) - F(l-i)|F(l) - F(l-j)>
             #   b(i)   =  <F(l) - F(l-i)|F(l)>
             # here dF = <F(l) - F(l-i)|
-            df = self._f[0] - self._f[1:]
+            df = self._f[0] - self._f[1:n+1]
             a = torch.einsum('i...v,j...v->...ij', df, df)
             b = torch.einsum('h...v,...v->...h', df, self._f[0])
 
@@ -505,12 +516,15 @@ class Anderson(_Mixer):
             # vectors by adding 1 + offset^2 to the diagonals of "a", see
             # equation 8.2 (Eyert)
             if self.diagonal_offset is not None:
-                a += a * (torch.eye(a.shape[-1], device=x_new.device)
-                      * (self.diagonal_offset ** 2))
+                a_scaled_diag = (a.diagonal(dim1=-2, dim2=-1)
+                                 * (1 + self.diagonal_offset ** 2))
+
+                a.diagonal(dim1=-2, dim2=-1)[...] = a_scaled_diag
 
             # Solve for the coefficients. As torch.solve cannot solve for 1D
             # tensors a blank dimension must be added
-            thetas = torch.squeeze(torch.linalg.solve(a, torch.unsqueeze(b, -1)))
+            thetas = torch.atleast_1d(
+                torch.squeeze(torch.linalg.solve(a, torch.unsqueeze(b, -1))))
 
             # Construct the 2'nd terms of eq 4.1 & 4.2 (Eyert). These are
             # the "averaged" histories of x and F respectively:
@@ -519,20 +533,10 @@ class Anderson(_Mixer):
             # These are not the x_bar & F_var values of eq. 4.1 & 4.2 (Eyert)
             # yet as they are still missing the 1st terms.
             x_bar = torch.einsum('...h,h...v->...v', thetas,
-                                 (self._x_hist[1:] - self._x_hist[0]))
+                                   (self._x_hist[1:n+1] - self._x_hist[0]))
             f_bar = torch.einsum('...h,h...v->...v', thetas, -df)
 
-            # The first terms of equations 4.1 & 4.2 (Eyert):
-            #   4.1: |x(l)> and & 4.2: |F(l)>
-            # Have been replaced by:
-            #   ϑ_0(l) * |x(j)> and ϑ_0(l) * |x(j)>
-            # respectively, where "ϑ_0(l)" is the coefficient for the current
-            # step and is defined as (Anderson):
-            #   ϑ_0(l) = 1 - sum(j=1 -> m) ϑ_j(l)
-            # Code deviates from DFTB+ here to prevent "stability issues"
-            # theta_0 = 1 - torch.sum(thetas)
-            # x_bar += theta_0 * self._x_hist[0]  # <- DFTB+
-            # f_bar += theta_0 * self._f[0]  # <- DFTB+
+            # Add in the first term
             x_bar += self._x_hist[0]
             f_bar += self._f[0]
 

--- a/tests/unittests/test_mixers.py
+++ b/tests/unittests/test_mixers.py
@@ -132,7 +132,7 @@ def func(x):
     return x + (-d * x - c * x**3)
 
 
-def cycle(mixer, target, function, arguments=None, n=200):
+def cycle(mixer, target, function, arguments=None, n=300):
     """Performs a self-consistency cycle using a specified mixer & function.
 
     Will check class is operating on the correct device.
@@ -143,39 +143,46 @@ def cycle(mixer, target, function, arguments=None, n=200):
         function: Function to be cycled, e.g. ``faux_SCC``.
         arguments: Tuple holding any other arguments that must be passed into
             ``function``.
-        n: Number of mixing cycles to perform.
+        n: Maximum number of mixing cycles to perform.
 
     Returns:
         converged: Tensor of booleans indicating convergence status.
         mixed: The final mixed system
 
     """
-    arguments = () if arguments is None else arguments
-    device = target.device
-    n_first = int(n / 2)
-    n_second = n - n_first
+    try:
+        arguments = () if arguments is None else arguments
+        device = target.device
+        n_first = 10
+        n_second = n - n_first
 
-    # "x_old" will only be provided for the first few cycles
-    for _ in range(n_first):
-        target = mixer(function(target, *arguments), target)
-    # After that it will have to rely on its internal tracking
-    for _ in range(n_second):
-        target = mixer(function(target, *arguments))
+        # "x_old" will only be provided for the first few cycles
+        for _ in range(n_first):
+            target = mixer(function(target, *arguments), target)
+        # After that it will have to rely on its internal tracking
+        for _ in range(n_second):
+            target = mixer(function(target, *arguments))
+            # If all systems are converged then break the loop to prevent
+            # possible over-convergence issues.
+            if torch.all(mixer.converged):
+                break
 
-    # Find floating point tensors that have been placed on the wrong device.
-    tensors = [k for k, v in mixer.__dict__.items() if isinstance(v, Tensor)
-               and v.dtype.is_floating_point and v.device != device]
-    cls = mixer.__class__.__name__
-    msg = (f'{cls}: The following tensors were placed on the wrong device\n'
-           f'\t{", ".join(tensors)}')
+        # Find floating point tensors that have been placed on the wrong device.
+        tensors = [k for k, v in mixer.__dict__.items() if isinstance(v, Tensor)
+                   and v.dtype.is_floating_point and v.device != device]
+        cls = mixer.__class__.__name__
+        msg = (f'{cls}: The following tensors were placed on the wrong device\n'
+               f'\t{", ".join(tensors)}')
 
-    # Assert everything is on the correct device
-    assert len(tensors) == 0, msg
-    assert device == target.device, f'{cls} device persistence check failed'
+        # Assert everything is on the correct device
+        assert len(tensors) == 0, msg
+        assert device == target.device, f'{cls} device persistence check failed'
 
-    converged = mixer.converged
-    mixer.reset()
-    return converged, target
+        converged = mixer.converged
+        mixer.reset()
+        return converged, target
+    finally:
+        mixer.reset()
 
 
 @pytest.mark.filterwarnings("ignore:Tolerance value")
@@ -225,11 +232,12 @@ def general(mixer, device):
 
     # Check 4
     b = a
-    a = mixer(func(a), a)
+    c = func(a)
+    a = mixer(c, a)
     chk_4a = mixer.delta.shape == a_copy.shape
-    chk_4b = torch.allclose(a - b, mixer.delta)
+    chk_4b = torch.allclose(c - b, mixer.delta)
     assert chk_4a, f'{name}.delta has an incorrect shape'
-    # assert chk_4b, f'{name}.delta values are not correct'
+    assert chk_4b, f'{name}.delta values are not correct'
 
     # Check 5
     converged = mixer.converged
@@ -279,22 +287,20 @@ def convergence(mixer, device):
 
     # CHECK 1:
     mixer._is_batch = False
-    _, res_0 = cycle(mixer, torch.ones(5, device=device), func, None, 400)
-    converged = torch.allclose(torch.zeros(5, device=device), res_0)
-    assert converged, f'{name}: Failed to converge to correct result'
+    conv_0, res_0 = cycle(mixer, torch.ones(5, device=device), func, None, 400)
+    assert conv_0, f'{name}: Failed to converge to correct result'
 
     # CHECK 2:
     # Check convergence of:
     #   1) A single vector
     conv_1, _ = cycle(mixer, q0[0], faux_SCC, (q0[0], H[0], S[0], G[0]))
     #   2) A single matrix
-    conv_2, res_1 = cycle(mixer, H[-1], faux_SCF, (q0[-1], H[-1], S[-1], G[-1]))
-    mixer._is_batch = True
+    conv_2, res_1 = cycle(mixer, H[0], faux_SCF, (q0[0], H[0], S[0], G[0]))
     #   3) A batch a of vectors
+    mixer._is_batch = True
     conv_3, _ = cycle(mixer, q0, faux_SCC, (q0, H, S, G))
     #   4) A of batch of a matrices
     conv_4, res_2 = cycle(mixer, H, faux_SCF, (q0, H, S, G))
-
 
     assert conv_1.all(), f'{name} Failed to converge single vector (faux_SCC)'
     assert conv_2.all(), f'{name} Failed to converge single matrix (faux_SCF)'
@@ -303,15 +309,17 @@ def convergence(mixer, device):
 
     # CHECK 3:
     # Ensure that batch & non-batch runs yield the same result
-    similar =  torch.allclose(res_1, res_2[-1])
+    similar = torch.allclose(res_1, res_2[0])
     assert similar, f'{name}: Batch operations return different results'
 
     # CHECK 4:
     # Check zero-padded packing does not adversely affect the final result
     # Ensure the same answer is given with padding as without padding.
-    s = (-1, slice(0,4), slice(0,4))
-    _, res_3 = cycle(mixer, H[s], faux_SCF, (q0[-1, :4,], H[s], S[s], G[s]))
-    similar = torch.allclose(res_3, res_1[:4, :4],)
+    mixer._is_batch = False
+    s = (-1, slice(0, 4), slice(0, 4))
+    _, res_3 = cycle(mixer, H[s], faux_SCF, (q0[-1, :4], H[s], S[s], G[s]))
+    _, res_4 = cycle(mixer, H[-1], faux_SCF, (q0[-1], H[-1], S[-1], G[-1]))
+    similar = torch.allclose(res_3, res_4[:4, :4],)
 
     assert similar, f'{name}: Zero padded packing returns different results'
     # Check 5 is carried out continuously by the cycle function.
@@ -332,8 +340,9 @@ def gradient(mixer, device):
         # F = H
         q_new = q0
         for _ in range(12):
-            # F = mixer(faux_SCF(F, q0, H, S, G), F)
             q_new = mixer(faux_SCC(q_new, q0, H, S, G), q_new)
+            if torch.all(mixer.converged):
+                break
 
         # Reset mixer before gradchecks next call
         mixer.reset()
@@ -341,7 +350,7 @@ def gradient(mixer, device):
         # return F
         return q_new
 
-    sizes = torch.tensor([5, 3], device=device)
+    sizes = torch.tensor([6, 4], device=device)
     # Generate test data
     H, S, G, q0 = gen_systems(device, sizes)
 
@@ -402,17 +411,14 @@ def test_anderson_general(device):
     assert reset, 'Reset operation was incomplete'
 
 
-@pytest.mark.skip(
-    reason="The H & S will result in a in anderson mixer singular tensor," 
-           " the real molecule testing do not has such problem")
 def test_anderson_convergence(device):
     mixer = Anderson(is_batch=False, tolerance=1E-6)
-    mixer.mix_param = 0.1
+    mixer.mix_param = 0.05
     convergence(mixer, device)
 
 
 @pytest.mark.grad
 def test_anderson_grad(device):
     mixer = Anderson(is_batch=True, tolerance=1E-6)
-    mixer.mix_param = 0.1
+    mixer.mix_param = 0.05
     gradient(mixer, device)


### PR DESCRIPTION
This fix makes some changes to the unit tests for the mixers to prevent over converging systems resulting in a the Anderson mixer failing due to a singular matrix error. Minor bugs causing a deceleration of the Anderson mixer have been patched.