### PR TITLE
Renamed `Basis` to `OrbitalInfo`

### DIFF
--- a/examples/example_01/example_01.py
+++ b/examples/example_01/example_01.py
@@ -3,7 +3,7 @@
 from os.path import exists
 from typing import Any
 import torch
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.ml.module import Calculator
 from tbmalt.physics.dftb import Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
@@ -55,12 +55,11 @@ target_path = 'target_data.json'
 # 2.1: Target system specific objects
 # -----------------------------------
 
-# Construct the `Geometry` and `Basis` objects. The former is analogous to the
-# ase.Atoms object while the latter provides information about what orbitals
-# are present and which atoms they belong two. `Basis` is perhaps a poor choice
-# of name and `OrbitalInfo` would be more appropriate.
+# Construct the `Geometry` and `OrbitalInfo` objects. The former is analogous
+# to the ase.Atoms object while the latter provides information about what
+# orbitals are present and which atoms they belong two.
 geometry = Geometry.from_ase_atoms(list(map(molecule, molecule_names)))
-basis = Basis(geometry.atomic_numbers, shell_dict, shell_resolved=False)
+orbs = OrbitalInfo(geometry.atomic_numbers, shell_dict, shell_resolved=False)
 
 # geometry[True, False, False, False]
 # 2.2: Loading of the DFTB parameters into their associated feed objects
@@ -97,7 +96,7 @@ u_feed = HubbardFeed.from_database(parameter_db_path, species)
 # As this is a minimal working example, no optional settings are provided to the
 # calculator object.
 dftb_calculator = Dftb2(h_feed, s_feed, o_feed, u_feed)
-dftb_calculator(geometry, basis)
+dftb_calculator(geometry, orbs)
 
 # Construct machine learning object
 lr = 0.002
@@ -174,7 +173,7 @@ def update_model(calculator: Calculator):
 if fit_model:
     for epoch in range(1, number_of_epochs + 1):
         # Perform the forwards operation
-        dftb_calculator(geometry, basis)
+        dftb_calculator(geometry, orbs)
 
         # Calculate the loss
         loss = calculate_losses(dftb_calculator, targets)
@@ -193,4 +192,4 @@ if fit_model:
         # dftb_calculator.reset()
 else:
     # Run the DFTB calculation
-    dftb_calculator(geometry, basis)
+    dftb_calculator(geometry, orbs)

--- a/examples/example_01/example_02.py
+++ b/examples/example_01/example_02.py
@@ -4,7 +4,7 @@ import random
 import torch
 import h5py
 
-from tbmalt import Basis
+from tbmalt import OrbitalInfo
 from tbmalt.ml.module import Calculator
 from tbmalt.physics.dftb import Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
@@ -93,12 +93,12 @@ else:
 
 # 2.2: Loading of the DFTB parameters into their associated feed objects
 # ----------------------------------------------------------------------
-# Construct the `Geometry` and `Basis` objects. The former is analogous to the
+# Construct the `Geometry` and `OrbitalInfo` objects. The former is analogous to the
 # ase.Atoms object while the latter provides information about what orbitals
-# are present and which atoms they belong two. `Basis` is perhaps a poor choice
+# are present and which atoms they belong two. `OrbitalInfo` is perhaps a poor choice
 # of name and `OrbitalInfo` would be more appropriate.
 # geometry = Geometry(atomic_numbers, positions, units='a')
-# basis = Basis(geometry.atomic_numbers, shell_dict, shell_resolved=False)
+# orbs = OrbitalInfo(geometry.atomic_numbers, shell_dict, shell_resolved=False)
 
 # Construct the Hamiltonian and overlap matrix feeds; but ensure that the DFTB
 # parameter set database actually exists first.
@@ -181,10 +181,10 @@ if fit_model:
     for epoch in range(number_of_epochs):
 
         data = dataloder[indice[epoch % len(indice)]]
-        basis = Basis(data.geometry.atomic_numbers, shell_dict, shell_resolved=False)
+        orbs = OrbitalInfo(data.geometry.atomic_numbers, shell_dict, shell_resolved=False)
 
         # Perform the forwards operation
-        dftb_calculator(data.geometry, basis)
+        dftb_calculator(data.geometry, orbs)
 
         # Calculate the loss
         loss = calculate_losses(dftb_calculator, data)

--- a/examples/example_dos/example_dos.py
+++ b/examples/example_dos/example_dos.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import numpy as np
 import h5py
 
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.ml.module import Calculator
 from tbmalt.physics.dftb import Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
@@ -263,10 +263,10 @@ def dftb_results(numbers, positions, cells, **kwargs):
     # Build objects for DFTB calculations
     geometry = Geometry(numbers, positions, cells, units='a',
                         cutoff=torch.tensor([18.0]))
-    basis = Basis(geometry.atomic_numbers, shell_dict, shell_resolved=False)
+    orbs = OrbitalInfo(geometry.atomic_numbers, shell_dict, shell_resolved=False)
 
     if not dftb:
-        dftb_calculator(geometry, basis)
+        dftb_calculator(geometry, orbs)
     else:
         # Build new feeds
         h_feed_o = SkFeed.from_database(parameter_db_path, species, 'hamiltonian',
@@ -278,7 +278,7 @@ def dftb_results(numbers, positions, cells, **kwargs):
         kwargs = {}
         kwargs['mix_params'] = mix_params
         dftb_calculator_o = Dftb2(h_feed_o, s_feed_o, o_feed, u_feed, **kwargs)
-        dftb_calculator_o(geometry, basis)
+        dftb_calculator_o(geometry, orbs)
 
     return dftb_calculator if not dftb else dftb_calculator_o
 

--- a/examples/example_dos/example_dos_ddp.py
+++ b/examples/example_dos/example_dos_ddp.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 import numpy as np
 import h5py
 
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.ml.module import Calculator
 from tbmalt.physics.dftb import Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
@@ -253,7 +253,7 @@ def dftb_results(numbers, positions, cells, h_feed_n, s_feed_n, **kwargs):
     # Build objects for DFTB calculations
     geometry = Geometry(numbers, positions, cells, units='a',
                         cutoff=torch.tensor([18.0]))
-    basis = Basis(geometry.atomic_numbers, shell_dict, shell_resolved=False)
+    orbs = OrbitalInfo(geometry.atomic_numbers, shell_dict, shell_resolved=False)
 
     mix_params = {'mix_param': 0.2, 'init_mix_param': 0.2,
               'generations': 3, 'tolerance': 1e-10}
@@ -263,7 +263,7 @@ def dftb_results(numbers, positions, cells, h_feed_n, s_feed_n, **kwargs):
     # Build objects for DFTB calculaitons
     dftb_calculator = Dftb2(h_feed_n, s_feed_n, o_feed, u_feed,
                             supress_SCF_error=True, **kwargs)
-    dftb_calculator(geometry, basis)
+    dftb_calculator(geometry, orbs)
 
     return dftb_calculator
 

--- a/tbmalt/__init__.py
+++ b/tbmalt/__init__.py
@@ -8,5 +8,5 @@ from tbmalt.common.exceptions import *
 
 # Pull data structure classes up to the tbmalt top level domain namespace
 from tbmalt.structures.geometry import Geometry
-from tbmalt.structures.basis import Basis
+from tbmalt.structures.orbitalinfo import OrbitalInfo
 from tbmalt.structures.periodic import Periodic

--- a/tbmalt/data/elements.py
+++ b/tbmalt/data/elements.py
@@ -26,7 +26,7 @@ Tensor = torch.Tensor
 
 
 # Highest atomic number the project can deal with. Currently this is only used
-# by the `Basis` class.
+# by the `OrbitalInfo` class.
 MAX_ATOMIC_NUMBER = 120
 
 # Chemical symbols of the elements. Neutronium is included to ensure the index

--- a/tbmalt/io/xtb/hamiltonian.py
+++ b/tbmalt/io/xtb/hamiltonian.py
@@ -3,7 +3,7 @@
 Definition of the global core Hamiltonian parameters.
 
 The core Hamiltonian is rescaling the shell-blocks of the overlap integrals
-formed over the basis set by the average of the atomic self-energies and an
+formed over the orbs set by the average of the atomic self-energies and an
 additional distance dependent function formed from the element parametrization.
 """
 

--- a/tbmalt/ml/acsf.py
+++ b/tbmalt/ml/acsf.py
@@ -8,7 +8,7 @@ import numpy as np
 from tbmalt import Geometry
 from tbmalt.common.batch import pack
 from tbmalt.data.units import length_units
-from tbmalt.structures.basis import _rows_to_NxNx2
+from tbmalt.structures.orbitalinfo import _rows_to_NxNx2
 
 
 class Acsf:
@@ -236,7 +236,7 @@ class Acsf:
             for j, jan in enumerate(self.unique_atomic_numbers[i:]):
                 _mask.append(torch.tensor([ian, jan], device=self._device))
         uniq_atom_pair = pack(_mask)
-        # anm = self.basis.atomic_number_matrix('atomic')
+        # anm = self.orbs.atomic_number_matrix('atomic')
 
         g_res = []
         for iu in uniq_atom_pair:

--- a/tbmalt/physics/xtb/feeds.py
+++ b/tbmalt/physics/xtb/feeds.py
@@ -16,7 +16,7 @@ from typing import Optional, Union
 
 import torch
 
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.ml import Feed
 from tbmalt.ml.integralfeeds import IntegralFeed
 from tbmalt.ml.module import require_args
@@ -41,8 +41,8 @@ class XtbOccupationFeed(Feed):
     Feed for reference occupation.
 
     A separate feed is required because the existing ones can only handle
-    a minimal basis. The extended tight-binding model, however, employs only
-    a *mostly* minimal basis.
+    a minimal orbs. The extended tight-binding model, however, employs only
+    a *mostly* minimal orbs.
     """
 
     def __init__(
@@ -100,8 +100,8 @@ class XtbOccupationFeed(Feed):
         """Floating point dtype used by feed object."""
         return self.__dtype
 
-    def __call__(self, basis: Basis) -> torch.Tensor:
-        numbers = basis.atomic_numbers
+    def __call__(self, orbs: OrbitalInfo) -> torch.Tensor:
+        numbers = orbs.atomic_numbers
 
         # helper for mapping atomic, orbital and shell indices
         ihelp = IndexHelper.from_numbers(numbers, get_elem_angular(self.par.element))
@@ -151,7 +151,7 @@ class XtbOverlapFeed(IntegralFeed):
     def matrix(self, geometry: Geometry):
         """
         Construct the overlap matrix.
-        The basis is constructed within the dxtb's `Hamiltonian` class.
+        The orbs is constructed within the dxtb's `Hamiltonian` class.
 
         Parameters
         ----------
@@ -199,7 +199,7 @@ class XtbHamiltonianFeed(IntegralFeed):
     def matrix(self, geometry: Geometry, overlap: torch.Tensor) -> torch.Tensor:
         """
         Construct the Hamiltonian matrix.
-        The basis is constructed within the dxtb's `Hamiltonian` class.
+        The orbs is constructed within the dxtb's `Hamiltonian` class.
 
         Parameters
         ----------

--- a/tbmalt/structures/orbitalinfo.py
+++ b/tbmalt/structures/orbitalinfo.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """A container to hold data associated with a chemical system's bases.
 
-This module provides the `Basis` data structure class and its associated code.
-The `Basis` class is intended to hold data needed to describe the number and
+This module provides the `OrbitalInfo` data structure class and its associated code.
+The `OrbitalInfo` class is intended to hold data needed to describe the number and
 identities of a chemical systems bases.
 """
 from typing import Dict, List, Union, Literal, Optional, Any
@@ -18,10 +18,10 @@ from tbmalt.data.elements import MAX_ATOMIC_NUMBER
 Form = Literal['full', 'shell', 'atomic']
 
 
-class Basis:
-    """Data container for all information relating to a system's basis set.
+class OrbitalInfo:
+    """Data container for all information relating to a system's orbs set.
 
-    This class collects all information about a system's basis set and its
+    This class collects all information about a system's orbs set and its
     orbitals into one place. This also permits calculations to
 
     Arguments:
@@ -49,6 +49,17 @@ class Basis:
         shell_ns (Tensor): The number of each shell, as defined by the order
             in which they were specified for relevant species.
 
+
+    Examples:
+        >>> from tbmalt import Geometry, OrbitalInfo
+        >>> from ase.build.molecule import molecule
+        >>> geometry = Geometry.from_ase_atoms(molecule('CH4'))
+        # Shell dictionary informing the `OrbitalInfo` entity that hydrogen
+        # atoms have a single s shell and carbon atoms an s and p shell.
+        >>> shell_dict = {1: [0], 6: [0, 1]}
+        >>> orbs = OrbitalInfo(geometry.atomic_numbers, shell_dict)
+
+
     Warnings:
         The order that each element's shell is specified in ``shell_dict`` is
         taken as the order in which integrals are yielded by `SkFeed` objects;
@@ -57,13 +68,9 @@ class Basis:
         1 and the atom_2_shell'th shell on atom 2.
 
 
-    Todo:
-        - The `Basis` class should be renamed to something more a little more
-            appropriate such as `OrbitalInformation`.
-
     """
     # Developers Notes:
-    # Basis instances only ever yield tensors used for masking or indexing
+    # OrbitalInfo instances only ever yield tensors used for masking or indexing
     # operations. As such the device on which they return results is somewhat
     # irrelevant. However, results are placed on the anticipated device anyway
     # to maintain expected behaviour.
@@ -145,13 +152,13 @@ class Basis:
 
     @property
     def device(self) -> torch.device:
-        """The device on which the `Basis` object resides."""
+        """The device on which the `OrbitalInfo` object resides."""
         return self.__device
 
     @device.setter
     def device(self, *args):
         # Instruct users to use the ".to" method if wanting to change device.
-        raise AttributeError('Basis object\'s dtype can only be modified '
+        raise AttributeError('OrbitalInfo object\'s dtype can only be modified '
                              'via the ".to" method.')
 
     @property
@@ -210,39 +217,39 @@ class Basis:
         return self._shells_per_species[self.atomic_numbers.view(-1)
                                         ].view_as(self.atomic_numbers)
 
-    def to(self, device: device) -> 'Basis':
-        """Returns a copy of the `Basis` instance on the specified device.
+    def to(self, device: device) -> 'OrbitalInfo':
+        """Returns a copy of the `OrbitalInfo` instance on the specified device.
 
-        This method creates and returns a new copy of the `Basis` instance
+        This method creates and returns a new copy of the `OrbitalInfo` instance
         on the specified device "``device``".
 
         Arguments:
             device: Device to which all associated tensors should be moved.
 
         Returns:
-            basis: Copy of the instance placed on the specified device.
+            orbs: Copy of the instance placed on the specified device.
 
         Notes:
-            If the `Basis` instance is already on the desired device then
+            If the `OrbitalInfo` instance is already on the desired device then
             `self` will be returned.
 
         """
         return self.__class__(self.atomic_numbers.to(device=device),
                               self.shell_dict, self.shell_resolved)
 
-    def __getitem__(self, selector) -> 'Basis':
-        """Permits batched Basis instances to be sliced as needed."""
+    def __getitem__(self, selector) -> 'OrbitalInfo':
+        """Permits batched OrbitalInfo instances to be sliced as needed."""
         # Block this if the instance has only a single system
         if self.atomic_numbers.ndim != 2:
             raise IndexError(
-                'Basis slicing is only applicable to batches of systems.')
+                'OrbitalInfo slicing is only applicable to batches of systems.')
 
         return self.__class__(deflate(self.atomic_numbers[selector, ...]),
                               self.shell_dict,
                               self.shell_resolved)
 
-    def __eq__(self, other: 'Basis') -> bool:
-        """Check if two `Basis` objects are equivalent."""
+    def __eq__(self, other: 'OrbitalInfo') -> bool:
+        """Check if two `OrbitalInfo` objects are equivalent."""
         # Note that batches with identical systems but a different order will
         # return False, not True.
 
@@ -259,16 +266,16 @@ class Basis:
             self.shell_resolved == other.shell_resolved
         ])
 
-    def __add__(self, other: 'Basis') -> 'Basis':
-        """Combine two `Basis` objects together."""
+    def __add__(self, other: 'OrbitalInfo') -> 'OrbitalInfo':
+        """Combine two `OrbitalInfo` objects together."""
         if self.__class__ != other.__class__:
             raise TypeError(
-                'Addition can only take place between two Basis objects.')
+                'Addition can only take place between two OrbitalInfo objects.')
 
         # Ensure that they both have the same resolution
         if self.shell_resolved != other.shell_resolved:
             raise AttributeError(
-                'Cannot add Basis with differing `shell_resolved` values.')
+                'Cannot add OrbitalInfo with differing `shell_resolved` values.')
 
         atomic_numbers = merge([
             torch.atleast_2d(self.atomic_numbers),
@@ -281,15 +288,15 @@ class Basis:
 
     @classmethod
     def from_hdf5(cls, source: Group, device: Optional[torch.device] = None
-                  ) -> 'Basis':
-        """Instantiate a `Basis` instances from an HDF5 group.
+                  ) -> 'OrbitalInfo':
+        """Instantiate a `OrbitalInfo` instances from an HDF5 group.
 
         Arguments:
-            source: An HDF5 group(s) containing `Basis` instance.
+            source: An HDF5 group(s) containing `OrbitalInfo` instance.
             device: Device on which to place tensors. [DEFAULT=None]
 
         Returns:
-            basis: The resulting `Basis` object.
+            orbs: The resulting `OrbitalInfo` object.
         """
         shell_dict = {int(k): v[()].tolist() for k, v in
                       source['shell_dict'].items()}
@@ -299,10 +306,10 @@ class Basis:
         return cls(atomic_numbers, shell_dict, shell_resolved)
 
     def to_hdf5(self, target: Group):
-        """Saves `Basis` instance into a target HDF5 Group.
+        """Saves `OrbitalInfo` instance into a target HDF5 Group.
 
         Arguments:
-            target: The hdf5 group to which the `Basis` should be saved.
+            target: The hdf5 group to which the `OrbitalInfo` should be saved.
 
         Notes:
             This function does not create its own group as it expects that
@@ -348,7 +355,7 @@ class Basis:
     def azimuthal_matrix(self, form: Form = 'full', sort: bool = False,
                          mask_on_site: bool = False, mask_diag: bool = False,
                          mask_lower: bool = False) -> Tensor:
-        r"""Azimuthal quantum numbers for each basis-basis interaction.
+        r"""Azimuthal quantum numbers for each orbs-orbs interaction.
 
         Tensor defining the azimuthal quantum numbers (ℓ) associated with each
         orbital-orbital interaction element.  Alternately, a shell form of
@@ -443,15 +450,15 @@ class Basis:
         if form == 'full':
             counts = self.shell_ls * 2 + 1
             counts[counts == -1] = 0
-            basis_list = self.shell_ls.repeat_interleave(counts.view(-1))
+            orbs_list = self.shell_ls.repeat_interleave(counts.view(-1))
             if batch:
-                basis_list = pack(split_by_size(basis_list, self.n_orbitals)
-                                  , value=-1)
+                orbs_list = pack(split_by_size(orbs_list, self.n_orbitals),
+                                 value=-1)
         else:
-            basis_list = self.shell_ls
+            orbs_list = self.shell_ls
 
         # Repeat and expand the vectors to get the final NxNx2 matrix tensor.
-        l_mat = _rows_to_NxNx2(basis_list, shape, -1)
+        l_mat = _rows_to_NxNx2(orbs_list, shape, -1)
 
         # If masking out parts of the matrix
         if mask_on_site | mask_lower | mask_diag:
@@ -484,7 +491,7 @@ class Basis:
         This is analogous to the ``azimuthal_matrix`` tensor but with shell
         numbers rather than azimuthal quantum numbers. The shell number for
         each species are taken from the order in which they are defined in
-        the `Basis.shell_dict`.
+        the `OrbitalInfo.shell_dict`.
 
         Arguments:
             form: Specifies the form of the shell number matrix:

--- a/tests/unittests/data/properties/dos/__init__.py
+++ b/tests/unittests/data/properties/dos/__init__.py
@@ -12,7 +12,7 @@ Notes:
 
 
 def _load_bases(path='./'):
-    """Load basis information."""
+    """Load orbs information."""
     file = join(path, 'bases.csv')
     keys = open(file, 'r').readline()[2:-1].split(', ')
     values = torch.tensor(loadtxt(file, delimiter=','), dtype=int)

--- a/tests/unittests/test_dftb.py
+++ b/tests/unittests/test_dftb.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from ase.build import molecule
 
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.physics.dftb import Dftb1, Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
 from tbmalt.common.batch import pack
@@ -62,7 +62,7 @@ def H2(device):
             [+0.000000000000000E+00, +0.000000000000000E+00, -6.965208740483853E-01]],
             device=device))
 
-    basis = Basis(
+    orbs = OrbitalInfo(
         torch.tensor([1, 1], device=device),
         {1: [0]})
 
@@ -94,7 +94,7 @@ def H2(device):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def H2_scc(device, **kwargs):
@@ -103,8 +103,8 @@ def H2_scc(device, **kwargs):
 
     geometry = Geometry.from_ase_atoms(molecule('H2'), device=device)
 
-    basis = Basis(geometry.atomic_numbers, {1: [0]},
-                  shell_resolved=shell_resolved)
+    orbs = OrbitalInfo(geometry.atomic_numbers, {1: [0]},
+                        shell_resolved=shell_resolved)
 
     results = {
         'q_final_atomic': torch.tensor([
@@ -114,7 +114,7 @@ def H2_scc(device, **kwargs):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 def H2O(device):
 
@@ -126,7 +126,7 @@ def H2O(device):
             [+0.000000000000000E+00, -1.442312573796989E+00, -9.014881136736096E-01]],
             device=device))
 
-    basis = Basis(
+    orbs = OrbitalInfo(
         torch.tensor([8, 1, 1], device=device),
         {8: [0, 1], 1: [0]})
 
@@ -165,7 +165,7 @@ def H2O(device):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def H2O_scc(device, **kwargs):
@@ -174,8 +174,8 @@ def H2O_scc(device, **kwargs):
 
     geometry = Geometry.from_ase_atoms(molecule('H2O'), device=device)
 
-    basis = Basis(geometry.atomic_numbers, {1: [0], 8: [0, 1]},
-                  shell_resolved=shell_resolved)
+    orbs = OrbitalInfo(geometry.atomic_numbers, {1: [0], 8: [0, 1]},
+                        shell_resolved=shell_resolved)
 
     results = {
         'q_final_atomic': torch.tensor([
@@ -185,7 +185,7 @@ def H2O_scc(device, **kwargs):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def CH4(device):
@@ -200,7 +200,7 @@ def CH4(device):
             [-1.188860634482795E+00, +1.188860634482795E+00, -1.188860634482795E+00]],
             device=device))
 
-    basis = Basis(
+    orbs = OrbitalInfo(
         torch.tensor([6, 1, 1, 1, 1], device=device),
         {1: [0], 6: [0, 1]})
 
@@ -243,7 +243,7 @@ def CH4(device):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def CH4_scc(device, **kwargs):
@@ -252,8 +252,8 @@ def CH4_scc(device, **kwargs):
 
     geometry = Geometry.from_ase_atoms(molecule('CH4'), device=device)
 
-    basis = Basis(geometry.atomic_numbers, {1: [0], 6: [0, 1]},
-                  shell_resolved=shell_resolved)
+    orbs = OrbitalInfo(geometry.atomic_numbers, {1: [0], 6: [0, 1]},
+                        shell_resolved=shell_resolved)
 
     results = {
         'q_final_atomic': torch.tensor([
@@ -264,7 +264,7 @@ def CH4_scc(device, **kwargs):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def CH3O(device):
@@ -279,7 +279,7 @@ def CH3O(device):
             [+2.307602986159369E+00, -1.678295886072759E+00, +2.230160125421416E-01]],
             device=device))
 
-    basis = Basis(
+    orbs = OrbitalInfo(
         torch.tensor([6, 8, 1, 1, 1], device=device),
         {8: [0, 1], 1: [0], 6: [0, 1]})
 
@@ -328,7 +328,7 @@ def CH3O(device):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def CH3O_scc(device, **kwargs):
@@ -337,8 +337,8 @@ def CH3O_scc(device, **kwargs):
 
     geometry = Geometry.from_ase_atoms(molecule('CH3O'), device=device)
 
-    basis = Basis(geometry.atomic_numbers, {1: [0], 6: [0, 1], 8:[0, 1]},
-                  shell_resolved=shell_resolved)
+    orbs = OrbitalInfo(geometry.atomic_numbers, {1: [0], 6: [0, 1], 8:[0, 1]},
+                        shell_resolved=shell_resolved)
 
     results = {
         'q_final_atomic': torch.tensor([
@@ -348,7 +348,7 @@ def CH3O_scc(device, **kwargs):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def C_wire_scc(device, **kwargs):
@@ -361,8 +361,8 @@ def C_wire_scc(device, **kwargs):
             [0.0, 0.0, 3.2], [0.0, 0.0, 4.0], [0.0, 0.0, 4.8], [0.0, 0.0, 5.6]],
             device=device), units='a')
 
-    basis = Basis(geometry.atomic_numbers, {6: [0, 1]},
-                  shell_resolved=shell_resolved)
+    orbs = OrbitalInfo(geometry.atomic_numbers, {6: [0, 1]},
+                        shell_resolved=shell_resolved)
 
     results = {
         'q_final_atomic': torch.tensor([
@@ -373,7 +373,7 @@ def C_wire_scc(device, **kwargs):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def Au13(device):
@@ -396,7 +396,7 @@ def Au13(device):
             [+9.515615391831613E-01, +9.515615391831613E-01, +0.000000000000000E+00]],
             device=device))
 
-    basis = Basis(
+    orbs = OrbitalInfo(
         torch.tensor([79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79], device=device),
         {79: [0, 1, 2]})
 
@@ -608,61 +608,61 @@ def Au13(device):
 
     kwargs = {'filling_scheme': 'fermi', 'filling_temp': 0.0036749324}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def merge_systems(device, *systems):
     """Combine multiple test systems into a batch."""
 
-    geometry, basis, results, kwargs = systems[0](device)
+    geometry, orbs, results, kwargs = systems[0](device)
 
     results = {k: [v] for k, v in results.items()}
 
     for system in systems[1:]:
-        t_geometry, t_basis, t_results, t_kwargs = system(device)
+        t_geometry, t_orbs, t_results, t_kwargs = system(device)
 
         assert t_kwargs == kwargs, 'Test systems with different settings ' \
                                    'cannot be used together'
 
         geometry += t_geometry
-        basis += t_basis
+        orbs += t_orbs
 
         for k, v in t_results.items():
             results[k].append(t_results[k])
 
     results = {k: pack(v) for k, v in results.items()}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def merge_systems_shell_resolved(device, *systems):
     """Combine multiple test systems into a batch."""
 
-    geometry, basis, results, kwargs = systems[0](device, shell_resolved=True)
+    geometry, orbs, results, kwargs = systems[0](device, shell_resolved=True)
 
     results = {k: [v] for k, v in results.items()}
 
     for system in systems[1:]:
-        t_geometry, t_basis, t_results, t_kwargs = system(device,
+        t_geometry, t_orbs, t_results, t_kwargs = system(device,
                                                           shell_resolved=True)
 
         assert t_kwargs == kwargs, 'Test systems with different settings ' \
                                    'cannot be used together'
 
         geometry += t_geometry
-        basis += t_basis
+        orbs += t_orbs
 
         for k, v in t_results.items():
             results[k].append(t_results[k])
 
     results = {k: pack(v) for k, v in results.items()}
 
-    return geometry, basis, results, kwargs
+    return geometry, orbs, results, kwargs
 
 
 def test_dftb1_general(device, shell_resolved_feeds):
     h_feed, s_feed, o_feed = shell_resolved_feeds
-    geometry, basis, results, kwargs = CH3O(device)
+    geometry, orbs, results, kwargs = CH3O(device)
 
     # Instantiate a blank calculator
     calculator = Dftb1(h_feed, s_feed, o_feed, **kwargs)
@@ -673,13 +673,13 @@ def test_dftb1_general(device, shell_resolved_feeds):
     pre_init_attr = [k for k in calculator.__dict__.keys()]
 
     # Those of which that are not yet initialised (excluding the geometry and
-    # basis attributes)
+    # orbs attributes)
     pre_init_null_attr = [
         k for k, v in calculator.__dict__.items()
-        if v is None and k not in ['_geometry', '_basis']]
+        if v is None and k not in ['_geometry', '_orbs']]
 
     # Run the calculator
-    _ = calculator(geometry, basis)
+    _ = calculator(geometry, orbs)
 
     # Check 1.1
     # See if any new attributes have been created that were not there before.
@@ -726,10 +726,10 @@ def test_dftb1_general(device, shell_resolved_feeds):
         calculator.__setattr__(c_attr, old_value)
 
 
-def dftb1_helper(calculator, geometry, basis, results):
+def dftb1_helper(calculator, geometry, orbs, results):
 
     # Trigger the calculation
-    _ = calculator(geometry, basis)
+    _ = calculator(geometry, orbs)
 
     # Ensure that the `hamiltonian` and `overlap` properties return the correct
     # matrices. We do not need to actually check if the matrices are themselves
@@ -767,10 +767,10 @@ def dftb1_helper(calculator, geometry, basis, results):
     # any errors should be caught elsewhere.
 
 
-def dftb2_helper(calculator, geometry, basis, results):
+def dftb2_helper(calculator, geometry, orbs, results):
 
     # Trigger the calculation
-    _ = calculator(geometry, basis)
+    _ = calculator(geometry, orbs)
 
     # Ensure that the `hamiltonian` and `overlap` properties return the correct
     # matrices. We do not need to actually check if the matrices are themselves
@@ -798,11 +798,11 @@ def test_dftb1_single(device, shell_resolved_feeds):
     systems = [H2, H2O, CH4, CH3O, Au13]
 
     for system in systems:
-        geometry, basis, results, kwargs = system(device)
+        geometry, orbs, results, kwargs = system(device)
 
         calculator = Dftb1(h_feed, s_feed, o_feed, **kwargs)
 
-        dftb1_helper(calculator, geometry, basis, results)
+        dftb1_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb1_batch(device, shell_resolved_feeds):
@@ -812,12 +812,12 @@ def test_dftb1_batch(device, shell_resolved_feeds):
                [H2, H2O, CH4, CH3O, Au13], [Au13, CH3O, CH4, H2, H2O]]
 
     for batch in batches:
-        geometry, basis, results, kwargs = merge_systems(device, *batch)
+        geometry, orbs, results, kwargs = merge_systems(device, *batch)
 
         calculator = Dftb1(h_feed, s_feed, o_feed, **kwargs)
         assert calculator.device == device, 'Calculator is on the wrong device'
 
-        dftb1_helper(calculator, geometry, basis, results)
+        dftb1_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb2_single(device, shell_resolved_feeds_scc):
@@ -826,11 +826,11 @@ def test_dftb2_single(device, shell_resolved_feeds_scc):
     systems = [H2_scc, H2O_scc, CH4_scc, CH3O_scc, C_wire_scc]
 
     for system in systems:
-        geometry, basis, results, kwargs = system(device)
+        geometry, orbs, results, kwargs = system(device)
 
         calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, **kwargs)
 
-        dftb2_helper(calculator, geometry, basis, results)
+        dftb2_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb2_batch(device, shell_resolved_feeds_scc):
@@ -840,12 +840,12 @@ def test_dftb2_batch(device, shell_resolved_feeds_scc):
                [H2_scc, H2O_scc, CH4_scc, CH3O_scc, C_wire_scc]]
 
     for batch in batches:
-        geometry, basis, results, kwargs = merge_systems(device, *batch)
+        geometry, orbs, results, kwargs = merge_systems(device, *batch)
 
         calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, **kwargs)
         assert calculator.device == device, 'Calculator is on the wrong device'
 
-        dftb2_helper(calculator, geometry, basis, results)
+        dftb2_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb2_single_shell_resolved(device, shell_resolved_feeds_scc):
@@ -854,11 +854,11 @@ def test_dftb2_single_shell_resolved(device, shell_resolved_feeds_scc):
     systems = [H2_scc, H2O_scc, CH4_scc, CH3O_scc, C_wire_scc]
 
     for system in systems:
-        geometry, basis, results, kwargs = system(device, shell_resolved=True)
+        geometry, orbs, results, kwargs = system(device, shell_resolved=True)
 
         calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, **kwargs)
 
-        dftb2_helper(calculator, geometry, basis, results)
+        dftb2_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb2_batch_shell_resolved(device, shell_resolved_feeds_scc):
@@ -868,13 +868,13 @@ def test_dftb2_batch_shell_resolved(device, shell_resolved_feeds_scc):
                [H2_scc, H2O_scc, CH4_scc, CH3O_scc, C_wire_scc]]
 
     for batch in batches:
-        geometry, basis, results, kwargs = merge_systems_shell_resolved(device,
+        geometry, orbs, results, kwargs = merge_systems_shell_resolved(device,
                                                                         *batch)
 
         calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, **kwargs)
         assert calculator.device == device, 'Calculator is on the wrong device'
 
-        dftb2_helper(calculator, geometry, basis, results)
+        dftb2_helper(calculator, geometry, orbs, results)
 
 
 def test_dftb2_batch_spl(device, shell_resolved_feeds_scc_spline):
@@ -884,9 +884,9 @@ def test_dftb2_batch_spl(device, shell_resolved_feeds_scc_spline):
                [H2_scc, H2O_scc, CH4_scc, CH3O_scc, C_wire_scc]]
 
     for batch in batches:
-        geometry, basis, results, kwargs = merge_systems(device, *batch)
+        geometry, orbs, results, kwargs = merge_systems(device, *batch)
 
         calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, **kwargs)
         assert calculator.device == device, 'Calculator is on the wrong device'
 
-        dftb2_helper(calculator, geometry, basis, results)
+        dftb2_helper(calculator, geometry, orbs, results)

--- a/tests/unittests/test_dftb_feeds_periodic.py
+++ b/tests/unittests/test_dftb_feeds_periodic.py
@@ -7,7 +7,7 @@ from typing import List
 import numpy as np
 from tbmalt.io.skf import Skf
 from tbmalt.physics.dftb.feeds import ScipySkFeed, SkfOccupationFeed, SkFeed
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.common.batch import pack
 from functools import reduce
 
@@ -148,8 +148,8 @@ def test_scipyskfeed_pbc_single(skf_file: str, device):
 
     for sys, H_ref, S_ref in zip(
             systems(device), hamiltonians(device), overlaps(device)):
-        H = H_feed.matrix(sys, Basis(sys.atomic_numbers, b_def))
-        S = S_feed.matrix(sys, Basis(sys.atomic_numbers, b_def))
+        H = H_feed.matrix(sys, OrbitalInfo(sys.atomic_numbers, b_def))
+        S = S_feed.matrix(sys, OrbitalInfo(sys.atomic_numbers, b_def))
 
         check_1 = torch.allclose(H, H_ref, atol=1E-2)
         check_2 = torch.allclose(S, S_ref, atol=1E-1)
@@ -168,18 +168,18 @@ def test_scipyskfeed_pbc_batch(skf_file: str, device):
         skf_file, [1, 6, 8, 16, 79], 'overlap', device=device)
 
     sys = reduce(lambda i, j: i+j, systems(device))
-    basis = Basis(sys.atomic_numbers,
-                  {1: [0], 6: [0, 1], 8: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
+    orbs = OrbitalInfo(sys.atomic_numbers,
+                        {1: [0], 6: [0, 1], 8: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
 
-    H = H_feed.matrix(sys, basis)
-    S = S_feed.matrix(sys, basis)
+    H = H_feed.matrix(sys, orbs)
+    S = S_feed.matrix(sys, orbs)
 
     check_1 = torch.allclose(H, pack(hamiltonians(device)), atol=1E-2)
     check_2 = torch.allclose(S, pack(overlaps(device)), atol=1E-1)
     check_3 = H.device == device
 
     # Check that batches of size one do not cause problems
-    check_4 = (H_feed.matrix(sys[0:1], basis[0:1]).ndim == 3)
+    check_4 = (H_feed.matrix(sys[0:1], orbs[0:1]).ndim == 3)
 
     assert check_1, 'ScipySkFeed H matrix outside of tolerance (batch)'
     assert check_2, 'ScipySkFeed S matrix outside of tolerance (batch)'
@@ -202,8 +202,8 @@ def test_skffeed_pbc_single(skf_file: str, device):
 
     for sys, H_ref, S_ref in zip(
             systems(device), hamiltonians(device), overlaps(device)):
-        H = H_feed.matrix(sys, Basis(sys.atomic_numbers, b_def))
-        S = S_feed.matrix(sys, Basis(sys.atomic_numbers, b_def))
+        H = H_feed.matrix(sys, OrbitalInfo(sys.atomic_numbers, b_def))
+        S = S_feed.matrix(sys, OrbitalInfo(sys.atomic_numbers, b_def))
 
         check_1 = torch.allclose(H, H_ref, atol=1E-12)
         check_2 = torch.allclose(S, S_ref, atol=1E-12)
@@ -222,18 +222,18 @@ def test_skffeed_pbc_batch(skf_file: str, device):
         skf_file, [1, 6, 8, 16, 79], 'overlap', device=device)
 
     sys = reduce(lambda i, j: i+j, systems(device))
-    basis = Basis(sys.atomic_numbers,
-                  {1: [0], 6: [0, 1], 8: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
+    orbs = OrbitalInfo(sys.atomic_numbers,
+                        {1: [0], 6: [0, 1], 8: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
 
-    H = H_feed.matrix(sys, basis)
-    S = S_feed.matrix(sys, basis)
+    H = H_feed.matrix(sys, orbs)
+    S = S_feed.matrix(sys, orbs)
 
     check_1 = torch.allclose(H, pack(hamiltonians(device)), atol=1E-12)
     check_2 = torch.allclose(S, pack(overlaps(device)), atol=1E-12)
     check_3 = H.device == device
 
     # Check that batches of size one do not cause problems
-    check_4 = (H_feed.matrix(sys[0:1], basis[0:1]).ndim == 3)
+    check_4 = (H_feed.matrix(sys[0:1], orbs[0:1]).ndim == 3)
 
     assert check_1, 'SkFeed H matrix outside of tolerance (batch)'
     assert check_2, 'SkFeed S matrix outside of tolerance (batch)'

--- a/tests/unittests/test_interpolation.py
+++ b/tests/unittests/test_interpolation.py
@@ -5,7 +5,7 @@ from scipy.interpolate import CubicSpline as SciCubSpl
 import pytest
 from tests.test_utils import *
 from tbmalt.common.maths.interpolation import PolyInterpU, CubicSpline, BicubInterp
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 torch.set_default_dtype(torch.float64)
 
 data = np.loadtxt('tests/unittests/data/polyinterp/HH.dat')

--- a/tests/unittests/test_mixers.py
+++ b/tests/unittests/test_mixers.py
@@ -54,7 +54,7 @@ def gen_systems(device, sizes):
     """Generates a batch of fake system for faux-SCC/SCF convergence testing.
 
     Returns variables needed to conduct faux-SCC/SCF cycles on a batch of
-    systems. Note; variables have no underling physical basis as they are
+    systems. Note; variables have no underling physical orbs as they are
     randomly generated.
 
     Returns:

--- a/tests/unittests/test_orbitalinfo.py
+++ b/tests/unittests/test_orbitalinfo.py
@@ -1,8 +1,8 @@
-"""Basis module unit-tests.
+"""OrbitalInfo module unit-tests.
 
-Here the functionality of the basis module is tested. However, it should be
+Here the functionality of the orbs module is tested. However, it should be
 noted that no gradient stability checks are performed as such tests are not
-applicable to the `Basis` class.
+applicable to the `OrbitalInfo` class.
 """
 import os
 import pytest
@@ -10,7 +10,7 @@ import numpy as np
 import h5py
 import torch
 from torch import allclose as close
-from tbmalt.structures.basis import Basis
+from tbmalt.structures.orbitalinfo import OrbitalInfo
 from tbmalt.common.batch import pack
 
 # Developers Notes
@@ -23,7 +23,7 @@ from tbmalt.common.batch import pack
 #########################
 # General Functionality #
 #########################
-def test_basis_operations(device):
+def test_orbs_operations(device):
     """Ensure general operators work as intended.
 
     These are operations like slicing, addition and equality. However, some
@@ -32,14 +32,14 @@ def test_basis_operations(device):
     bd = {1: [0], 6: [0, 1]}
 
 
-    H2 = Basis(torch.tensor([1, 1], device=device), bd)
-    H2_shell_resolved = Basis(torch.tensor([1, 1], device=device), bd, True)
-    batched_H2 = Basis([torch.tensor([1, 1], device=device)], bd)
+    H2 = OrbitalInfo(torch.tensor([1, 1], device=device), bd)
+    H2_shell_resolved = OrbitalInfo(torch.tensor([1, 1], device=device), bd, True)
+    batched_H2 = OrbitalInfo([torch.tensor([1, 1], device=device)], bd)
 
-    CH4 = Basis(torch.tensor([6, 1, 1, 1, 1], device=device), bd)
+    CH4 = OrbitalInfo(torch.tensor([6, 1, 1, 1, 1], device=device), bd)
 
-    H2_CH4 = Basis([torch.tensor([1, 1], device=device),
-                    torch.tensor([6, 1, 1, 1, 1], device=device)], bd)
+    H2_CH4 = OrbitalInfo([torch.tensor([1, 1], device=device),
+                          torch.tensor([6, 1, 1, 1, 1], device=device)], bd)
 
     # Check that error is raise when combining systems with difering shell resolutions
 
@@ -50,12 +50,12 @@ def test_basis_operations(device):
     check_1d = H2 != batched_H2  # Special False case 2
     check_1 = all([check_1a, check_1b, check_1c, check_1d])
 
-    assert check_1, 'Basis equality evaluates incorrect'
+    assert check_1, 'OrbitalInfo equality evaluates incorrect'
 
 
     # Addition
     check_2 = (H2 + CH4) == H2_CH4 == (batched_H2 + CH4)
-    assert check_2, 'Basis addition did not perform as expected'
+    assert check_2, 'OrbitalInfo addition did not perform as expected'
     with pytest.raises(AttributeError):
         H2 + H2_shell_resolved
 
@@ -82,19 +82,19 @@ def test_basis_operations(device):
     check_5 = check_5a and check_5b
     assert check_5, "Batch.n_orbs_on_species failed to yield the correct results"
 
-def test_basis_basic_single(device):
-    """General operational test of basic Basis functionality (single)."""
-    # Generate test basis entity
+def test_orbs_basic_single(device):
+    """General operational test of basic OrbitalInfo functionality (single)."""
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([1, 1, 6, 6, 79, 79], device=device)
     shell_dict = {1: [0], 6: [0, 1], 79: [0, 1, 2]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     # Ensure exceptions are raised if shell_dict keys are not lists of ints
     with pytest.raises(ValueError):
-        _ = Basis(atomic_numbers, {1: [torch.tensor(0)], 6: [0, 1]})
+        _ = OrbitalInfo(atomic_numbers, {1: [torch.tensor(0)], 6: [0, 1]})
 
     with pytest.raises(ValueError):
-        _ = Basis(atomic_numbers, {1: torch.tensor([0]), 6: [0, 1]})
+        _ = OrbitalInfo(atomic_numbers, {1: torch.tensor([0]), 6: [0, 1]})
 
     # Reference data
     orbs_per_atom = torch.tensor([1, 1, 4, 4, 9, 9], device=device)
@@ -106,51 +106,51 @@ def test_basis_basic_single(device):
     shell_ls = torch.tensor([0, 0, 0, 1, 0, 1, 0, 1, 2, 0, 1, 2], device=device)
 
     # Counter properties
-    check_1a = basis.n_atoms == 6
-    check_1b = basis.n_shells == 12
-    check_1c = basis.n_orbitals == 28
+    check_1a = orbs.n_atoms == 6
+    check_1b = orbs.n_shells == 12
+    check_1c = orbs.n_orbitals == 28
 
     assert check_1a, 'n_atoms is incorrect'
     assert check_1b, 'n_subshells is incorrect'
     assert check_1c, 'n_orbitals is incorrect'
 
     # Shape properties
-    check_2a = basis.atomic_matrix_shape == torch.Size([6, 6])
-    check_2b = basis.shell_matrix_shape == torch.Size([12, 12])
-    check_2c = basis.orbital_matrix_shape == torch.Size([28, 28])
+    check_2a = orbs.atomic_matrix_shape == torch.Size([6, 6])
+    check_2b = orbs.shell_matrix_shape == torch.Size([12, 12])
+    check_2c = orbs.orbital_matrix_shape == torch.Size([28, 28])
 
     assert check_2a, 'atomic_matrix_shape is incorrect'
     assert check_2b, 'subshell_matrix_shape is incorrect'
     assert check_2c, 'orbital_matrix_shape is incorrect'
 
-    check_2da = basis.matrix_shape('atomic') == torch.Size([6, 6])
-    check_2db = basis.matrix_shape('shell') == torch.Size([12, 12])
-    check_2dc = basis.matrix_shape('full') == torch.Size([28, 28])
+    check_2da = orbs.matrix_shape('atomic') == torch.Size([6, 6])
+    check_2db = orbs.matrix_shape('shell') == torch.Size([12, 12])
+    check_2dc = orbs.matrix_shape('full') == torch.Size([28, 28])
     check_2d = check_2da and check_2db and check_2dc
 
     assert check_2d, 'matrix_shape function returned an unexpected shape'
 
     # Orbital counter properties (location specific)
-    check_3a = close(basis.orbs_per_atom, orbs_per_atom)
-    check_3b = close(basis.orbs_per_shell, orbs_per_shell)
+    check_3a = close(orbs.orbs_per_atom, orbs_per_atom)
+    check_3b = close(orbs.orbs_per_shell, orbs_per_shell)
 
     assert check_3a, 'orbs_per_atom is incorrect'
     assert check_3b, 'orbs_per_shell is incorrect'
 
     # Orbital location properties
-    check_4a = close(basis.on_atoms, on_atoms)
-    check_4b = close(basis.on_shells, on_shells)
+    check_4a = close(orbs.on_atoms, on_atoms)
+    check_4b = close(orbs.on_shells, on_shells)
 
     assert check_4a, 'on_atoms is incorrect'
     assert check_4b, 'on_atoms is incorrect'
 
     # Resolution convenience functions
-    basis.shell_resolved = False
-    check_5a = close(basis.orbs_per_res, orbs_per_atom)
-    check_9a = close(basis.on_res, on_atoms)
-    basis.shell_resolved = True
-    check_5b = close(basis.orbs_per_res, orbs_per_shell)
-    check_9b = close(basis.on_res, on_shells)
+    orbs.shell_resolved = False
+    check_5a = close(orbs.orbs_per_res, orbs_per_atom)
+    check_9a = close(orbs.on_res, on_atoms)
+    orbs.shell_resolved = True
+    check_5b = close(orbs.orbs_per_res, orbs_per_shell)
+    check_9b = close(orbs.on_res, on_shells)
     check_5 = check_5a and check_5b
     check_6 = check_9a and check_9b
 
@@ -158,7 +158,7 @@ def test_basis_basic_single(device):
     assert check_6, 'on_res is incorrect'
 
     # Check shell_ls
-    check_7 = close(basis.shell_ls, shell_ls)
+    check_7 = close(orbs.shell_ls, shell_ls)
 
     assert check_7, 'shell_ls is incorrect'
 
@@ -167,7 +167,7 @@ def test_basis_basic_single(device):
              'orbs_per_shell', 'on_atoms', 'on_shells', 'shell_ls']
 
     for attr in attrs:
-        check_8 = basis.__getattribute__(attr).device == device
+        check_8 = orbs.__getattribute__(attr).device == device
         assert check_8, f'Attribute {attr} returned on the wrong device.'
 
     # Ensure "to" method functions as expected
@@ -175,24 +175,24 @@ def test_basis_basic_single(device):
         # Select a device to move to
         new_device = {'cuda': torch.device('cpu'),
                       'cpu': torch.device('cuda:0')}[device.type]
-        basis_copy = basis.to(new_device)
-        check_9a = basis_copy.atomic_numbers.device == new_device
+        orbs_copy = orbs.to(new_device)
+        check_9a = orbs_copy.atomic_numbers.device == new_device
 
         # Check that the .device property was correctly set
-        check_9b = new_device == basis_copy.device
+        check_9b = new_device == orbs_copy.device
         check_6 = check_9a and check_9b
 
         assert check_6, '".to" method failed to set the correct device'
 
 
-def test_basis_basic_batch(device):
-    """General operational test of basic Basis functionality (batch)."""
-    # Generate test basis entity
+def test_orbs_basic_batch(device):
+    """General operational test of basic OrbitalInfo functionality (batch)."""
+    # Generate test orbs entity
     dev = {'device': device}
     atomic_numbers = [torch.tensor([1, 1, 6, 6, 79, 79], **dev),
                       torch.tensor([1, 6], **dev)]
     shell_dict = {1: [0], 6: [0, 1], 79: [0, 1, 2]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     # Reference data
     orbs_per_atom = torch.tensor([[1, 1, 4, 4, 9, 9],
@@ -213,44 +213,44 @@ def test_basis_basic_batch(device):
                              [0, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1]], **dev)
 
     # Counter properties
-    check_1a = close(basis.n_atoms, torch.tensor([6, 2], **dev))
-    check_1b = close(basis.n_shells, torch.tensor([12, 3], **dev))
-    check_1c = close(basis.n_orbitals, torch.tensor([28, 5], **dev))
+    check_1a = close(orbs.n_atoms, torch.tensor([6, 2], **dev))
+    check_1b = close(orbs.n_shells, torch.tensor([12, 3], **dev))
+    check_1c = close(orbs.n_orbitals, torch.tensor([28, 5], **dev))
 
     assert check_1a, 'n_atoms is incorrect'
     assert check_1b, 'n_subshells is incorrect'
     assert check_1c, 'n_orbitals is incorrect'
 
     # Shape properties
-    check_2a = basis.atomic_matrix_shape == torch.Size([2, 6, 6])
-    check_2b = basis.shell_matrix_shape == torch.Size([2, 12, 12])
-    check_2c = basis.orbital_matrix_shape == torch.Size([2, 28, 28])
+    check_2a = orbs.atomic_matrix_shape == torch.Size([2, 6, 6])
+    check_2b = orbs.shell_matrix_shape == torch.Size([2, 12, 12])
+    check_2c = orbs.orbital_matrix_shape == torch.Size([2, 28, 28])
 
     assert check_2a, 'atomic_matrix_shape is incorrect'
     assert check_2b, 'subshell_matrix_shape is incorrect'
     assert check_2c, 'orbital_matrix_shape is incorrect'
 
     # Orbital counter properties (location specific)
-    check_3a = close(basis.orbs_per_atom, orbs_per_atom)
-    check_3b = close(basis.orbs_per_shell, orbs_per_shell)
+    check_3a = close(orbs.orbs_per_atom, orbs_per_atom)
+    check_3b = close(orbs.orbs_per_shell, orbs_per_shell)
 
     assert check_3a, 'orbs_per_atom is incorrect'
     assert check_3b, 'orbs_per_shell is incorrect'
 
     # Orbital location properties
-    check_4a = close(basis.on_atoms, on_atoms)
-    check_4b = close(basis.on_shells, on_shells)
+    check_4a = close(orbs.on_atoms, on_atoms)
+    check_4b = close(orbs.on_shells, on_shells)
 
     assert check_4a, 'on_atoms is incorrect'
     assert check_4b, 'on_atoms is incorrect'
 
     # Resolution convenience functions
-    basis.shell_resolved = False
-    check_5a = close(basis.orbs_per_res, orbs_per_atom)
-    check_6a = close(basis.on_res, on_atoms)
-    basis.shell_resolved = True
-    check_5b = close(basis.orbs_per_res, orbs_per_shell)
-    check_6b = close(basis.on_res, on_shells)
+    orbs.shell_resolved = False
+    check_5a = close(orbs.orbs_per_res, orbs_per_atom)
+    check_6a = close(orbs.on_res, on_atoms)
+    orbs.shell_resolved = True
+    check_5b = close(orbs.orbs_per_res, orbs_per_shell)
+    check_6b = close(orbs.on_res, on_shells)
     check_5 = check_5a and check_5b
     check_6 = check_6a and check_6b
 
@@ -258,26 +258,26 @@ def test_basis_basic_batch(device):
     assert check_6, 'on_res is incorrect'
 
     # Check shell_ls
-    check_7 = close(basis.shell_ls, shell_ls)
+    check_7 = close(orbs.shell_ls, shell_ls)
 
     assert check_7, 'shell_ls is incorrect'
 
     # Make sure pre-packed tensors can be passed in
-    basis_2 = Basis(pack(atomic_numbers), shell_dict)
-    # If basis_2's "shell_ls" attribute is the same as basis, then it will
+    orbs_2 = OrbitalInfo(pack(atomic_numbers), shell_dict)
+    # If orbs_2's "shell_ls" attribute is the same as orbs, then it will
     # perform identically.
-    check_8 = torch.allclose(basis_2.shell_ls, basis.shell_ls)
+    check_8 = torch.allclose(orbs_2.shell_ls, orbs.shell_ls)
 
-    assert check_8, 'Basis instantiate incorrectly with pre-packed arguments'
+    assert check_8, 'OrbitalInfo instantiate incorrectly with pre-packed arguments'
 
 
 #################
-# Basis HDF5 IO #
+# OrbitalInfo HDF5 IO #
 ##################
-def basis_hdf5_helper(basis):
+def orbs_hdf5_helper(orbs):
     """Function to reduce code duplication when testing the HDF5 functionality."""
-    path = 'basis_test_db.hdf5'
-    device = basis.device
+    path = 'orbs_test_db.hdf5'
+    device = orbs.device
 
     # Ensure any test hdf5 database is erased before running
     if os.path.exists(path):
@@ -287,53 +287,53 @@ def basis_hdf5_helper(basis):
     with h5py.File(path, 'w') as db:
         # Check 1: Write to the database and check that the written data
         # matches the reference data.
-        basis.to_hdf5(db)
-        check_1a = np.allclose(db['atomic_numbers'][()], basis.atomic_numbers.cpu().numpy())
-        check_1b = [np.allclose(np.array(basis.shell_dict[int(k)]), v[()])
+        orbs.to_hdf5(db)
+        check_1a = np.allclose(db['atomic_numbers'][()], orbs.atomic_numbers.cpu().numpy())
+        check_1b = [np.allclose(np.array(orbs.shell_dict[int(k)]), v[()])
                     for k, v in db['shell_dict'].items()]
-        check_1c = db['shell_resolved'][()] == basis.shell_resolved
+        check_1c = db['shell_resolved'][()] == orbs.shell_resolved
         check_1 = check_1a and check_1b and check_1c
 
-        assert check_1, 'Basis not saved the database correctly'
+        assert check_1, 'OrbitalInfo not saved the database correctly'
 
         # Check 2: Ensure geometries are correctly constructed from hdf5 data
-        basis_2 = Basis.from_hdf5(db, device=device)
-        check_2 = (torch.allclose(basis_2.atomic_numbers, basis.atomic_numbers)
-                   and torch.allclose(basis_2.shell_ls, basis.shell_ls)
-                   and basis.shell_resolved == basis_2.shell_resolved)
+        orbs_2 = OrbitalInfo.from_hdf5(db, device=device)
+        check_2 = (torch.allclose(orbs_2.atomic_numbers, orbs.atomic_numbers)
+                   and torch.allclose(orbs_2.shell_ls, orbs.shell_ls)
+                   and orbs.shell_resolved == orbs_2.shell_resolved)
 
-        assert check_2, 'Basis could not be loaded from hdf5 data'
+        assert check_2, 'OrbitalInfo could not be loaded from hdf5 data'
 
         # Check 3: Make sure that the tensors were placed on the correct device
-        check_3 = basis_2.atomic_numbers.device == device
-        assert check_3, 'Basis not placed on the correct device'
+        check_3 = orbs_2.atomic_numbers.device == device
+        assert check_3, 'OrbitalInfo not placed on the correct device'
 
     # Remove the test database
     os.remove(path)
 
 
-def test_basis_hdf5_single(device):
+def test_orbs_hdf5_single(device):
     atomic_numbers = torch.tensor([1, 1, 6, 6, 79, 79], device=device)
     shell_dict = {1: [0], 6: [0, 1], 79: [0, 1, 2]}
-    basis_hdf5_helper(Basis(atomic_numbers, shell_dict, shell_resolved=True))
+    orbs_hdf5_helper(OrbitalInfo(atomic_numbers, shell_dict, shell_resolved=True))
 
 
-def test_basis_hdf5_batch(device):
+def test_orbs_hdf5_batch(device):
     atomic_numbers = torch.tensor([[1, 1, 6, 6, 79, 79],
                                    [1, 6, 0, 0, 0, 0]], device=device)
     shell_dict = {1: [0], 6: [0, 1], 79: [0, 1, 2]}
-    basis_hdf5_helper(Basis(atomic_numbers, shell_dict, shell_resolved=True))
+    orbs_hdf5_helper(OrbitalInfo(atomic_numbers, shell_dict, shell_resolved=True))
 
 
 ########################
-# Basis Matrix Methods #
+# OrbitalInfo Matrix Methods #
 ########################
-def test_basis_azimuthal_matrix_single(device):
-    # Generate test basis entity
+def test_orbs_azimuthal_matrix_single(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([1, 1, 1, 1, 6], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
 
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = torch.stack([
         torch.tensor(
@@ -381,18 +381,18 @@ def test_basis_azimuthal_matrix_single(device):
 
     # Check un-masked and un-sorted full and block azimuthal matrices
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, False, False, False, False)
+        mat = orbs.azimuthal_matrix(option, False, False, False, False)
         check_1 = close(mat, ref)
         assert check_1, f'{option} azimuthal matrix is incorrect, no sort/mask'
 
     # Sorting
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, True, False, False, False)
+        mat = orbs.azimuthal_matrix(option, True, False, False, False)
         check_2 = close(mat, ref.sort(-1)[0])
         assert check_2, f'{option} sorted azimuthal matrix is incorrect'
 
     # Diagonal masking (only applicable to full)
-    mat = basis.azimuthal_matrix('full', False, False, True, False)
+    mat = orbs.azimuthal_matrix('full', False, False, True, False)
     full_ref_masked = full_ref.clone()
     full_ref_masked.diagonal()[:] = -1
     check_3 = close(mat, full_ref_masked)
@@ -400,15 +400,15 @@ def test_basis_azimuthal_matrix_single(device):
 
     # Lower triangle masking
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, False, False, False, True)
+        mat = orbs.azimuthal_matrix(option, False, False, False, True)
         ref = ref.clone()
         ref[[*torch.tril_indices(*ref.shape[:-1], -1)]] = -1
         check_4 = close(mat, ref)
         assert check_4, f'{option}: lower triangular masking is incorrect'
 
     # On-site masking
-    full_mat = basis.azimuthal_matrix('full', False, True, False, False)
-    block_mat = basis.azimuthal_matrix('shell', False, True, False, False)
+    full_mat = orbs.azimuthal_matrix('full', False, True, False, False)
+    block_mat = orbs.azimuthal_matrix('shell', False, True, False, False)
     # Build reference matrices for full and block
     full_ref_masked = full_ref.clone()
     mask = torch.block_diag(*[torch.full((i, i), True) for i in [1, 1, 1, 1, 4]])
@@ -416,7 +416,7 @@ def test_basis_azimuthal_matrix_single(device):
     full_ref_masked[mask] = -1
 
     block_ref_masked = block_ref.clone()
-    idx_mat = basis.index_matrix('shell')
+    idx_mat = orbs.index_matrix('shell')
     block_ref_masked[idx_mat[..., 0] == idx_mat[..., 1]] = -1
 
     check_5a = close(full_mat, full_ref_masked)
@@ -426,17 +426,17 @@ def test_basis_azimuthal_matrix_single(device):
 
     # Ensure an exception is raised if an invalid option was passed
     with pytest.raises(ValueError):
-        basis.azimuthal_matrix('invalid_option')
+        orbs.azimuthal_matrix('invalid_option')
     with pytest.raises(ValueError):
-        basis.azimuthal_matrix('atomic')
+        orbs.azimuthal_matrix('atomic')
 
 
-def test_basis_azimuthal_matrix_batch(device):
-    # Generate test basis entity
+def test_orbs_azimuthal_matrix_batch(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([[1, 1, 1, 1, 6],
                                    [1, 6, 0, 0, 0]], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = pack([
         torch.stack([
@@ -516,18 +516,18 @@ def test_basis_azimuthal_matrix_batch(device):
 
     # Check un-masked and un-sorted full and block azimuthal matrices
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, False, False, False, False)
+        mat = orbs.azimuthal_matrix(option, False, False, False, False)
         check_1 = close(mat, ref)
         assert check_1, f'{option} azimuthal matrix is incorrect, no sort/mask'
 
     # Sorting
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, True, False, False, False)
+        mat = orbs.azimuthal_matrix(option, True, False, False, False)
         check_2 = close(mat, ref.sort(-1)[0])
         assert check_2, f'{option} sorted azimuthal matrix is incorrect'
 
     # Diagonal masking (only applicable to full)
-    mat = basis.azimuthal_matrix('full', False, False, True, False)
+    mat = orbs.azimuthal_matrix('full', False, False, True, False)
     full_ref_masked = full_ref.clone()
     full_ref_masked.diagonal(dim1=1, dim2=2)[:] = -1
     check_3 = close(mat, full_ref_masked)
@@ -535,7 +535,7 @@ def test_basis_azimuthal_matrix_batch(device):
 
     # Lower triangle masking
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.azimuthal_matrix(option, False, False, False, True)
+        mat = orbs.azimuthal_matrix(option, False, False, False, True)
         # Create masked reference matrix
         ref = ref.clone()
         a, b = [*torch.tril_indices(*ref.shape[1:-1], -1)]
@@ -545,8 +545,8 @@ def test_basis_azimuthal_matrix_batch(device):
         assert check_4, f'{option}: lower triangular masking is incorrect'
 
     # On-site masking
-    full_mat = basis.azimuthal_matrix('full', False, True, False, False)
-    block_mat = basis.azimuthal_matrix('shell', False, True, False, False)
+    full_mat = orbs.azimuthal_matrix('full', False, True, False, False)
+    block_mat = orbs.azimuthal_matrix('shell', False, True, False, False)
     # Build reference matrices for full and block
     full_ref_masked = full_ref.clone()
     mask = pack([
@@ -558,7 +558,7 @@ def test_basis_azimuthal_matrix_batch(device):
     full_ref_masked[mask] = -1
 
     block_ref_masked = block_ref.clone()
-    idx_mat = basis.index_matrix('shell')
+    idx_mat = orbs.index_matrix('shell')
     block_ref_masked[idx_mat[..., 0] == idx_mat[..., 1]] = -1
 
     check_5a = close(full_mat, full_ref_masked)
@@ -567,12 +567,12 @@ def test_basis_azimuthal_matrix_batch(device):
     assert check_5b, 'block azimuthal matrix onsite masking failed'
 
 
-def test_basis_shell_number_matrix_single(device):
-    # Generate test basis entity
+def test_orbs_shell_number_matrix_single(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([1, 1, 1, 1, 6], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
 
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = torch.stack([
         torch.tensor(
@@ -619,7 +619,7 @@ def test_basis_shell_number_matrix_single(device):
             ])], -1).to(device)
 
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.shell_number_matrix(option)
+        mat = orbs.shell_number_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 
@@ -628,17 +628,17 @@ def test_basis_shell_number_matrix_single(device):
 
         # Ensure an exception is raised if an invalid option was passed
     with pytest.raises(ValueError):
-        basis.shell_number_matrix('invalid_option')
+        orbs.shell_number_matrix('invalid_option')
     with pytest.raises(ValueError):
-        basis.shell_number_matrix('atomic')
+        orbs.shell_number_matrix('atomic')
 
 
-def test_basis_shell_number_matrix_batch(device):
-    # Generate test basis entity
+def test_orbs_shell_number_matrix_batch(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([[1, 1, 1, 1, 6],
                                    [1, 6, 0, 0, 0]], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = pack([
         torch.stack([
@@ -717,7 +717,7 @@ def test_basis_shell_number_matrix_batch(device):
                 ])], -1)], value=-1).to(device)
 
     for option, ref in zip(['full', 'shell'], [full_ref, block_ref]):
-        mat = basis.shell_number_matrix(option)
+        mat = orbs.shell_number_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 
@@ -726,16 +726,16 @@ def test_basis_shell_number_matrix_batch(device):
 
         # Ensure an exception is raised if an invalid option was passed
     with pytest.raises(ValueError):
-        basis.shell_number_matrix('invalid_option')
+        orbs.shell_number_matrix('invalid_option')
     with pytest.raises(ValueError):
-        basis.shell_number_matrix('atomic')
+        orbs.shell_number_matrix('atomic')
         
 
-def test_basis_atomic_number_matrix_single(device):
-    # Generate test basis entity
+def test_orbs_atomic_number_matrix_single(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([1, 1, 1, 1, 6], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = torch.stack([
         torch.tensor(
@@ -801,7 +801,7 @@ def test_basis_atomic_number_matrix_single(device):
 
     for option, ref in zip(['full', 'shell', 'atomic'],
                            [full_ref, block_ref, atomic_ref]):
-        mat = basis.atomic_number_matrix(option)
+        mat = orbs.atomic_number_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 
@@ -810,15 +810,15 @@ def test_basis_atomic_number_matrix_single(device):
 
     # Ensure an exception is raised if an invalid option was passed
     with pytest.raises(ValueError):
-        basis.atomic_number_matrix('invalid_option')
+        orbs.atomic_number_matrix('invalid_option')
 
 
-def test_basis_atomic_number_matrix_batch(device):
-    # Generate test basis entity
+def test_orbs_atomic_number_matrix_batch(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([[1, 1, 1, 1, 6],
                                    [1, 6, 0, 0, 0]], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = pack([
         torch.stack([
@@ -928,18 +928,18 @@ def test_basis_atomic_number_matrix_batch(device):
 
     for option, ref in zip(['full', 'shell', 'atomic'],
                            [full_ref, block_ref, atomic_ref]):
-        mat = basis.atomic_number_matrix(option)
+        mat = orbs.atomic_number_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 
         assert check_1, f'{option} atomic number matrix is incorrect'
         assert check_2, f'{option} atomic number matrix is on the wrong device'
 
-def test_basis_index_matrix_single(device):
-    # Generate test basis entity
+def test_orbs_index_matrix_single(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([1, 1, 1, 1, 6], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = torch.stack([
         torch.tensor(
@@ -1005,7 +1005,7 @@ def test_basis_index_matrix_single(device):
 
     for option, ref in zip(['full', 'shell', 'atomic'],
                            [full_ref, block_ref, atomic_ref]):
-        mat = basis.index_matrix(option)
+        mat = orbs.index_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 
@@ -1014,15 +1014,15 @@ def test_basis_index_matrix_single(device):
 
     # Ensure an exception is raised if an invalid option was passed
     with pytest.raises(ValueError):
-        basis.index_matrix('invalid_option')
+        orbs.index_matrix('invalid_option')
 
 
-def test_basis_index_matrix_batch(device):
-    # Generate test basis entity
+def test_orbs_index_matrix_batch(device):
+    # Generate test orbs entity
     atomic_numbers = torch.tensor([[1, 1, 1, 1, 6],
                                    [1, 6, 0, 0, 0]], device=device)
     shell_dict = {1: [0], 6: [0, 1]}
-    basis = Basis(atomic_numbers, shell_dict)
+    orbs = OrbitalInfo(atomic_numbers, shell_dict)
 
     full_ref = pack([
         torch.stack([
@@ -1132,7 +1132,7 @@ def test_basis_index_matrix_batch(device):
 
     for option, ref in zip(['full', 'shell', 'atomic'],
                            [full_ref, block_ref, atomic_ref]):
-        mat = basis.index_matrix(option)
+        mat = orbs.index_matrix(option)
         check_1 = close(mat, ref)
         check_2 = mat.device == device
 

--- a/tests/unittests/test_xtb.py
+++ b/tests/unittests/test_xtb.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 import torch
 
-from tbmalt import Geometry, Basis
+from tbmalt import Geometry, OrbitalInfo
 from tbmalt.ml.module import Calculator
 from tbmalt.physics.dftb import Dftb1, Dftb2
 from tbmalt.physics.dftb.feeds import HubbardFeed
@@ -287,7 +287,7 @@ def test_dftb1_single(device: torch.device, name: str, skf_file) -> None:
     geometry = Geometry(numbers, positions)
 
     # H has a second s-function in GFN1-xTB!!
-    basis = Basis(numbers, get_elem_angular(GFN1_XTB.element))
+    basis = OrbitalInfo(numbers, get_elem_angular(GFN1_XTB.element))
 
     # create (integral) feeds
     h_feed = Gfn1HamiltonianFeed(GFN1_XTB, dtype, device)
@@ -314,7 +314,7 @@ def test_dftb1_batch(device: torch.device, name1: str, name2: str, skf_file) -> 
     geometry = Geometry(numbers, positions)
 
     # H has a second s-function in GFN1-xTB!!
-    basis = Basis(numbers, get_elem_angular(GFN1_XTB.element))
+    basis = OrbitalInfo(numbers, get_elem_angular(GFN1_XTB.element))
 
     # create (integral) feeds
     h_feed = Gfn1HamiltonianFeed(GFN1_XTB, dtype, device)
@@ -341,7 +341,7 @@ def test_dftb2_single(device: torch.device, name: str, skf_file) -> None:
     geometry = Geometry(numbers, positions)
 
     # H has a second s-function in GFN1-xTB!!
-    basis = Basis(numbers, {1: [0, 0], 6: [0, 1], 8: [0, 1]})
+    basis = OrbitalInfo(numbers, {1: [0, 0], 6: [0, 1], 8: [0, 1]})
 
     # create (integral) feeds
     h_feed = Gfn1HamiltonianFeed(GFN1_XTB, dtype, device)
@@ -370,7 +370,7 @@ def test_dftb2_batch(device: torch.device, name1: str, name2: str, skf_file) -> 
     geometry = Geometry(numbers, positions)
 
     # H has a second s-function in GFN1-xTB!!
-    basis = Basis(numbers, get_elem_angular(GFN1_XTB.element))
+    basis = OrbitalInfo(numbers, get_elem_angular(GFN1_XTB.element))
 
     # create (integral) feeds
     h_feed = Gfn1HamiltonianFeed(GFN1_XTB, dtype, device)


### PR DESCRIPTION
Renamed the `Basis` class to `OrbitalInfo` so that the name is more representative of its function.