### PR TITLE
Clean skf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         # Dependencies are not installed via 'requirements.txt' to prevent the download of 800 MB.
         run: |
           python -m pip install --upgrade pip
-          pip install pytest h5py ase typing pydantic tomli dscribe 
+          pip install pytest h5py ase typing 'pydantic>=1.10.0,<2.0.0' tomli dscribe 
           pip3 install torch==1.12.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
       - name: Test with pytest
         run: |


### PR DESCRIPTION
1. revise minor documentation problems;
2. add examples in the `Skf`;
3. temporarily fix the `Pydantic` version (<2.0) to resolve testing errors in `xtb`.