### PR TITLE
SkFeed refactoring

### DIFF
--- a/examples/example_01/example_01.py
+++ b/examples/example_01/example_01.py
@@ -103,13 +103,13 @@ lr = 0.002
 criterion = getattr(torch.nn, 'MSELoss')(reduction='mean')
 
 h_var, s_var = [], []
-for key in h_feed.off_sites.keys():
+for key in h_feed._off_sites.keys():
 
     # Collect spline parameters and add to optimizer
-    h_feed.off_sites[key].coefficients.requires_grad_(True)
-    s_feed.off_sites[key].coefficients.requires_grad_(True)
-    h_var.append({'params': h_feed.off_sites[key].coefficients, 'lr': lr})
-    s_var.append({'params': s_feed.off_sites[key].coefficients, 'lr': lr})
+    h_feed._off_sites[key].coefficients.requires_grad_(True)
+    s_feed._off_sites[key].coefficients.requires_grad_(True)
+    h_var.append({'params': h_feed._off_sites[key].coefficients, 'lr': lr})
+    s_var.append({'params': s_feed._off_sites[key].coefficients, 'lr': lr})
 
 optimizer = getattr(torch.optim, 'Adam')(h_var + s_var, lr=lr)
 

--- a/examples/example_01/example_02.py
+++ b/examples/example_01/example_02.py
@@ -135,8 +135,8 @@ dftb_calculator = Dftb2(h_feed, s_feed, o_feed, u_feed)
 # Construct machine learning object
 lr = 0.003
 criterion = getattr(torch.nn, 'MSELoss')(reduction='mean')
-h_var = [val.coefficients for key, val in h_feed.off_sites.items()]
-s_var = [val.coefficients for key, val in s_feed.off_sites.items()]
+h_var = [val.coefficients for key, val in h_feed._off_sites.items()]
+s_var = [val.coefficients for key, val in s_feed._off_sites.items()]
 optimizer = getattr(torch.optim, 'Adam')(h_var + s_var, lr=lr)
 
 

--- a/examples/example_01/example_03.py
+++ b/examples/example_01/example_03.py
@@ -272,8 +272,8 @@ def single_fit(dftb_calculator, dataloder, n_batch, global_r):
                     for iatm in data.geometry.unique_atomic_numbers().tolist()}
 
         # Perform the forwards operation
-        dftb_calculator.h_feed.vcr = this_cr
-        dftb_calculator.s_feed.vcr = this_cr
+        dftb_calculator.h_feed.compression_radii = this_cr
+        dftb_calculator.s_feed.compression_radii = this_cr
         dftb_calculator(data.geometry, orbs)
 
         # Calculate the loss
@@ -303,7 +303,7 @@ def single_fit(dftb_calculator, dataloder, n_batch, global_r):
 
     # store optimized results to dftb calculator
     if global_r:
-        dftb_calculator.h_feed.vcr = comp_r
+        dftb_calculator.h_feed.compression_radii = comp_r
     else:
         dftb_calculator.h_feed.on_sites = onsite_dict
 
@@ -360,7 +360,7 @@ def single_test(dftb_calculator: Dftb2,
 
         # Collect ML input and reference
         x_fit = build_feature(geometry_fit, orbs_fit)
-        y_fit = dftb_calculator.h_feed.vcr.detach()
+        y_fit = dftb_calculator.h_feed.compression_radii.detach()
         y_fit = y_fit[geometry_fit.atomic_numbers.ne(0)]
         x_test = build_feature(geometry_test, orbs_test)
 
@@ -383,17 +383,17 @@ def single_test(dftb_calculator: Dftb2,
                 for iatm in geometry_test.unique_atomic_numbers().tolist()}
 
         # Update predicted compression radii and onsite
-        dftb_calculator.h_feed.vcr = y_pred
-        dftb_calculator.s_feed.vcr = y_pred
+        dftb_calculator.h_feed.compression_radii = y_pred
+        dftb_calculator.s_feed.compression_radii = y_pred
     else:
-        comp_r = dftb_calculator.h_feed.vcr
+        comp_r = dftb_calculator.h_feed.compression_radii
         this_cr = torch.ones(geometry_test.atomic_numbers.shape)
         for ii, iatm in enumerate(geometry_test.unique_atomic_numbers()):
             this_cr[iatm == geometry_test.atomic_numbers] = comp_r[ii]
 
         # Perform the forwards operation
-        dftb_calculator.h_feed.vcr = this_cr
-        dftb_calculator.s_feed.vcr = this_cr
+        dftb_calculator.h_feed.compression_radii = this_cr
+        dftb_calculator.s_feed.compression_radii = this_cr
 
     # Perform DFTB calculations
     dftb_calculator_std(geometry_test, orbs_test)

--- a/examples/example_dos/example_dos.py
+++ b/examples/example_dos/example_dos.py
@@ -295,8 +295,8 @@ def main(rank, world_size, train_dataset, data_train_dos):
     """ML training to optimize DFTB H and S matrix."""
     # Initial the model
     train_data = data_split(rank, world_size, train_dataset, batch_size=n_batch)
-    h_var = [val.coefficients for key, val in h_feed.off_sites.items()]
-    s_var = [val.coefficients for key, val in s_feed.off_sites.items()]
+    h_var = [val.coefficients for key, val in h_feed._off_sites.items()]
+    s_var = [val.coefficients for key, val in s_feed._off_sites.items()]
     variable = h_var + s_var
     optimizer = getattr(torch.optim, 'Adam')(variable, lr=lr)
     loss_list = []

--- a/examples/example_dos/example_dos_ddp.py
+++ b/examples/example_dos/example_dos_ddp.py
@@ -288,8 +288,8 @@ class DFTB_DDP(nn.Module):
 
     def __init__(self):
         super(DFTB_DDP, self).__init__()
-        h_var = [val.coefficients for key, val in h_feed.off_sites.items()]
-        s_var = [val.coefficients for key, val in s_feed.off_sites.items()]
+        h_var = [val.coefficients for key, val in h_feed._off_sites.items()]
+        s_var = [val.coefficients for key, val in s_feed._off_sites.items()]
         variable = h_var + s_var
 
         self.parameters = nn.ParameterList([nn.Parameter(ivar)
@@ -304,11 +304,11 @@ class DFTB_DDP(nn.Module):
         h_var_u = var[:len(var)//2]
         s_var_u = var[len(var)//2:]
         ii = 0
-        for key, val in h_feed_p.off_sites.items():
+        for key, val in h_feed_p._off_sites.items():
             val.coefficients = h_var_u[ii]
             ii = ii + 1
         ii = 0
-        for key, val in s_feed_p.off_sites.items():
+        for key, val in s_feed_p._off_sites.items():
             val.coefficients = s_var_u[ii]
             ii = ii + 1
 
@@ -369,11 +369,11 @@ def main(rank, world_size, dataset_train, dataset_test, data_train_dos):
             h_var_u = var[:len(var)//2]
             s_var_u = var[len(var)//2:]
             ii = 0
-            for key, val in h_feed_p.off_sites.items():
+            for key, val in h_feed_p._off_sites.items():
                 val.coefficients = h_var_u[ii]
                 ii = ii + 1
             ii = 0
-            for key, val in s_feed_p.off_sites.items():
+            for key, val in s_feed_p._off_sites.items():
                 val.coefficients = s_var_u[ii]
                 ii = ii + 1
             test(0, 1, dataset_test, h_feed_p, s_feed_p)

--- a/tbmalt/common/maths/interpolation.py
+++ b/tbmalt/common/maths/interpolation.py
@@ -10,12 +10,11 @@ from tbmalt.ml import Feed
 Tensor = torch.Tensor
 
 
+class BicubInterpSpl(Feed):
+    """Special purpose Bicubic like interpolation method.
 
-class BicubInterp:
-    """Bicubic interpolation method.
-
-    The bicubic interpolation is designed to interpolate the integrals with
-    given compression radii or distances.
+    This bicubic like interpolation method is designed to interpolate Slater-
+    Koster integrals over both compression radii and distances.
 
     Arguments:
         compr: Grid points for interpolation, 1D Tensor.
@@ -24,6 +23,11 @@ class BicubInterp:
         hs_grid: Distances at which the ``hamiltonian`` & ``overlap``
             elements were evaluated.
 
+    Notes:
+        This feed does not contain any optimisable parameters as it is not
+        intended to be optimised directly. Instead, it is the compression
+        radii of the atoms that are to be optimised.
+
     Examples:
         >>> import matplotlib.pyplot as plt
         >>> import torch
@@ -31,7 +35,7 @@ class BicubInterp:
         >>> y = torch.arange(0., 5., 0.25)
         >>> xx, yy = torch.meshgrid(x, y)
         >>> z = torch.sin(xx) + torch.cos(yy)
-        >>> bi_interp = BicubInterp(x, z)
+        >>> bi_interp = BicubInterpSpl(x, z)
         >>> xnew = torch.arange(0., 5., 1e-2)
         >>> ynew = torch.arange(0., 5., 1e-2)
         >>> znew = bi_interp(torch.stack([xnew, ynew]).T)
@@ -44,6 +48,7 @@ class BicubInterp:
     """
 
     def __init__(self, compr: Tensor, zmesh: Tensor, hs_grid=None):
+        super().__init__()
 
         assert zmesh.shape[-2] == zmesh.shape[-2], \
             'Size of last two dimensions of zmesh must be the same.'
@@ -63,7 +68,6 @@ class BicubInterp:
 
         # Device type of the tensor in this class
         self._device = compr.device
-
 
     def __call__(self, rr: Tensor, distances=None):
         """Calculate bicubic interpolation.
@@ -96,8 +100,8 @@ class BicubInterp:
             assert distances is not None, 'if hs_grid is not None, '+ \
                 'distances is expected'
 
-            ski = PolyInterpU(self.hs_grid, self.zmesh)
-            zmesh = ski(distances).permute(0, -2, -1, 1)
+            ski = PolyInterpU(self.hs_grid, Parameter(self.zmesh, requires_grad=False))
+            zmesh = ski.forward(distances).permute(0, -2, -1, 1)
         elif self.zmesh.dim() == 2 or self.zmesh.dim() == 3:
             zmesh = self.zmesh.repeat(rr.shape[0], 1, 1)
         else:
@@ -135,6 +139,25 @@ class BicubInterp:
         znew = torch.stack([torch.matmul(torch.matmul(
             xmat[:, i, 0], a_mat[i]), xmat[:, i, 1]) for i in range(self.batch)])
         return znew
+
+    def forward(self, rr: Tensor, distances=None):
+        """Perform the bicubic-like interpolation.
+
+        If distances is not None, the polynomial interpolation will be
+        used to interpolate distances from ``hamiltonian`` & ``overlap``.
+        Then the bicubic interpolation will be used to interpolate rr
+        from the interpolated ``hamiltonian`` & ``overlap`` values.
+
+        Arguments:
+            rr: The points to be interpolated for the first dimension and
+                second dimension.
+            distances: Distances between atoms.
+
+        Returns:
+            znew: Interpolation values with given rr, or rr and distances.
+
+        """
+        return self(rr, distances=distances)
 
     def _get_indices(self, xi):
         """Get indices and repeat indices."""
@@ -198,40 +221,40 @@ class BicubInterp:
                 fxy01, fxy10, fxy11)
 
 
-class PolyInterpU:
+class PolyInterpU(Feed):
     """Polynomial interpolation method with uniform grid points.
 
     The boundary condition will use `poly_to_zero` function, which make the
     polynomial values smoothly converge to zero at the boundary.
 
     Arguments:
-        xx: Grid points for interpolation, 1D Tensor.
-        yy: Values to be interpolated at each grid point.
+        x: Grid points for interpolation, 1D Tensor.
+        y: Values to be interpolated at each grid point. Note that this must
+            be a `torch.nn.Parameter` rather than a standard torch `Tensor`.
         tail: Distance to smooth the tail.
         delta_r: Delta distance for 1st, 2nd derivative.
         n_interp: Number of total interpolation grid points.
         n_interp_r: Number of right side interpolation grid points.
 
     Attributes:
-        xx: Grid points for interpolation, 1D Tensor.
-        yy: Values to be interpolated at each grid point.
         delta_r: Delta distance for 1st, 2nd derivative.
         tail: Distance to smooth the tail.
         n_interp: Number of total interpolation grid points.
         n_interp_r: Number of right side interpolation grid points.
-        grid_step: Distance between each gird points.
 
     Notes:
         The `PolyInterpU` class, which is taken from the DFTB+, assumes a
-        uniform grid. Here, the yy and xx arguments are the values to be
+        uniform grid. Here, the y and x arguments are the values to be
         interpolated and their associated grid points respectively. The tail
         end of the spline is smoothed to zero, meaning that extrapolated
         points will rapidly, but smoothly, decay to zero.
 
     Examples:
+        >>> import torch
+        >>> from torch.nn import Parameter
         >>> import matplotlib.pyplot as plt
         >>> x = torch.linspace(0, 2. * torch.pi, 100)
-        >>> y = torch.sin(x)
+        >>> y = Parameter(torch.sin(x), requires_grad=False)
         >>> poly = PolyInterpU(x, y, n_interp=8, n_interp_r=4)
         >>> new_x = torch.rand(10) * 2. * torch.pi
         >>> new_y = poly(new_x)
@@ -241,38 +264,97 @@ class PolyInterpU:
 
     """
 
-    # TODO: Resolve bug causing incorrect value to be returned when
-    #  interpolating at the last grid point.
+    # TODO:
+    #   - Resolve bug causing incorrect value to be returned when
+    #     interpolating at the last grid point.
+    #   - Either implement cache based updating to detect when changes have
+    #     been made to tensor contents or make it clear through documentation
+    #     what is not permitted to be modified.
 
-    def __init__(self, xx: Tensor, yy: Tensor, tail: Real = 1.0,
-                 delta_r: Real = 1E-5, n_interp: int = 8, n_interp_r: int = 4):
-        self.xx = xx
-        self.yy = yy
+    def __init__(
+            self, x: Tensor, y: Parameter, tail: Real = 1.0,
+            delta_r: Real = 1E-5, n_interp: int = 8, n_interp_r: int = 4):
+
+        super().__init__()
+
+        if not torch.allclose(x.diff(), x[1] - x[0]):
+            raise ValueError("Spacing of grid points must be uniform.")
+
+        # Ensure that the y values are a parameter instance
+        if not isinstance(y, Parameter):
+            warnings.warn(
+                "An instance of `torch.nn.Parameter` was expected for the "
+                "attribute `y`, but a `torch.Tensor` was received. The tensor "
+                "will be automatically cast to a parameter.",
+                UserWarning)
+            y = Parameter(y, requires_grad=y.requires_grad)
+
+        self._x = x
+        self._y = y
         self.delta_r = delta_r
 
-        self.tail = tail
+        self._tail = tail
         self.n_interp = n_interp
         self.n_interp_r = n_interp_r
-        self.grid_step = xx[1] - xx[0]
 
         # Device type of the tensor in this class
-        self._device = xx.device
+        self._device = x.device
 
         # Get grid points with external tail for index operation
-        self.n_tail = int(self.tail / self.grid_step)
-        self.xx_ext = torch.linspace(
-            self.xx[0], self.xx[-1] + self.tail,
-            len(self.xx) + self.n_tail, device=self._device)
+        self._x_ext = self._build_external_tail()
 
         # Check xx is uniform & that len(xx) > n_interp
-        dxs = xx[1:] - xx[:-1]
-        check_1 = torch.allclose(dxs, torch.full_like(dxs, self.grid_step))
-        assert check_1, 'Grid points xx are not uniform'
-        if len(xx) < n_interp:
+        if len(x) < n_interp:
             raise ValueError(f'`n_interp` ({n_interp}) exceeds the number of'
-                             f'data points `xx` ({len(xx)}).')
+                             f'data points `xx` ({len(x)}).')
 
-    def __call__(self, rr: Tensor) -> Tensor:
+    @property
+    def y(self) -> Tensor:
+        """Interpolation values"""
+        return self._y
+
+    @y.setter
+    def y(self, y: Tensor):
+        if not isinstance(y, Parameter):
+            warnings.warn(
+                "An instance of `torch.nn.Parameter` was expected for the "
+                "attribute `y`, but a `torch.Tensor` was received. The tensor "
+                "will be automatically cast to a parameter.",
+                UserWarning)
+            y = Parameter(y, requires_grad=y.requires_grad)
+        self._y = y
+
+    @property
+    def x(self) -> Tensor:
+        """Interpolation grid points"""
+        return self._x
+
+    @x.setter
+    def x(self, x: Tensor):
+        # If a new array of x values have been provided then ensure that it is
+        # the right length.
+        if not torch.allclose(x.diff(), x[1] - x[0]):
+            raise ValueError("Spacing of grid points must be uniform.")
+
+        self._x = x
+        self._x_ext = self._build_external_tail()
+
+    @property
+    def tail(self) -> Real:
+        """Distance over which to smooth the tail to zero."""
+        return self._tail
+
+    @tail.setter
+    def tail(self, tail):
+        self._tail = tail
+        self._x_ext = self._build_external_tail()
+
+    @property
+    def device(self) -> torch.device:
+        """Device on which data is located."""
+        return self._device
+
+    def forward(self, rr: Tensor) -> Tensor:
         """Get interpolation according to given rr.
 
         Arguments:
@@ -282,13 +364,15 @@ class PolyInterpU:
             result: Interpolation values with given rr.
 
         """
-        n_grid_point = len(self.xx)  # -> number of grid points
+        n_grid_point = len(self._x)  # -> number of grid points
 
-        ind = torch.searchsorted(self.xx_ext, rr).to(self._device)
+        grid_step = self.x[1] - self.x[0]
+
+        ind = torch.searchsorted(self._x_ext, rr).to(self._device)
         result = (
             torch.zeros(rr.shape, device=self._device)
-            if self.yy.dim() == 1
-            else torch.zeros(rr.shape[0], *self.yy.shape[1:], device=self._device)
+            if self._y.dim() == 1
+            else torch.zeros(rr.shape[0], *self._y.shape[1:], device=self._device)
         )
 
         # => polynomial fit
@@ -300,42 +384,61 @@ class PolyInterpU:
             ind_last[ind_last > n_grid_point] = n_grid_point
             ind_last[ind_last < self.n_interp + 1] = self.n_interp + 1
 
-            # gather xx and yy for both single and batch
-            xa = self.xx[0] + (ind_last.unsqueeze(1) - self.n_interp - 1 +
+            # gather x and y for both single and batch
+            xa = self._x[0] + (ind_last.unsqueeze(1) - self.n_interp - 1 +
                                torch.arange(self.n_interp, device=self._device)
-                               ) * self.grid_step
-            yb = torch.stack([self.yy[ii - self.n_interp - 1: ii - 1]
+                               ) * grid_step
+            yb = torch.stack([self._y[ii - self.n_interp - 1: ii - 1]
                               for ii in ind_last]).to(self._device)
 
             result[_mask] = poly_interp(xa, yb, rr[_mask])
 
         # Beyond the grid => extrapolation with polynomial of 5th order
-        max_ind = n_grid_point - 1 + int(self.tail / self.grid_step)
+        max_ind = n_grid_point - 1 + int(self._tail / grid_step)
         is_tail = ind.masked_fill(ind.ge(n_grid_point) * ind.le(max_ind), -1).eq(-1)
         if is_tail.any():
-            r_max = self.xx[-2] + self.tail
+            r_max = self._x[-2] + self._tail
             dr = rr[is_tail] - r_max
-            dr = dr.unsqueeze(-1) if self.yy.dim() == 2 else dr
+            dr = dr.unsqueeze(-1) if self._y.dim() == 2 else dr
             ilast = n_grid_point
 
             # get grid points and grid point values
             xa = (ilast - self.n_interp + torch.arange(
-                self.n_interp, device=self._device) - 1) * self.grid_step + self.xx[0]
-            yb = self.yy[ilast - self.n_interp - 1: ilast - 1]
+                self.n_interp, device=self._device) - 1) * grid_step + self._x[0]
+            yb = self._y[ilast - self.n_interp - 1: ilast - 1]
             xa = xa.repeat(dr.shape[0]).reshape(dr.shape[0], -1)
             yb = yb.unsqueeze(0).repeat_interleave(dr.shape[0], dim=0)
 
             # get derivative
             y0 = poly_interp(xa, yb, xa[:, self.n_interp - 1] - self.delta_r)
             y2 = poly_interp(xa, yb, xa[:, self.n_interp - 1] + self.delta_r)
-            y1 = self.yy[ilast - 2]
+            y1 = self._y[ilast - 2]
             y1p = (y2 - y0) / (2.0 * self.delta_r)
             y1pp = (y2 + y0 - 2.0 * y1) / (self.delta_r * self.delta_r)
 
             result[is_tail] = poly_to_zero(
-                dr, -1.0 * self.tail, -1.0 / self.tail, y1, y1p, y1pp)
+                dr, -1.0 * self._tail, -1.0 / self._tail, y1, y1p, y1pp)
 
         return result
+
+    def _build_external_tail(self):
+        """Compute and return the external tail.
+
+        Returns:
+            external_tail: The external tail.
+        """
+        xx = self._x
+        tail = self._tail
+        return torch.linspace(
+            xx[0], xx[-1] + tail,
+            len(xx) + int(tail / (xx[1] - xx[0])),
+            device=self._device)
+
+    def __call__(self, *args, **kwargs) -> Tensor:
+        warnings.warn(
+            "`PolyInterpU` instances should be invoked via their "
+            "`.forward` method now.")
+        return self.forward(*args, **kwargs)
 
 
 def poly_to_zero(xx: Tensor, dx: Tensor, inv_dist: Tensor,
@@ -385,7 +488,7 @@ def poly_interp(xp: Tensor, yp: Tensor, rr: Tensor) -> Tensor:
 
     Notes:
         The function `poly_interp` is designed for both single and multi
-        systems interpolation. Therefore xp will be 2D Tensor.
+        system interpolation. Therefore, xp will be 2D Tensor.
 
     """
     assert xp.dim() == 2, 'xp is not 2D Tensor'
@@ -437,15 +540,14 @@ class CubicSpline(Feed):
     spline which is twice continuously differentiable.
 
     Arguments:
-        xx: A one dimensional tensor specifying the interpolation grid points,
+        x: A one dimensional tensor specifying the interpolation grid points,
             i.e. the knot locations.
-        yy: Interpolation values, i.e. the knot values, associated with each
-            grid point. For single series interpolation this should be a tensor
+        y: Interpolation values, i.e. the knot values, associated with each
+            grid point. For single series interpolation this should be an array
             of length "n", where "n" is the number of grid points present in
-            ``xx``. For batch interpolation this should be an "m" by "n"
-            tensor. Note that `Parameter` should be used in place of `Tensor`
-            instances when wishing to use the knot values as an optimisation
-            target.
+            ``x``. For batch interpolation this should be an "m" by "n"
+            tensor. Note that this should be a `Parameter` rather than `Tensor`
+            instance.
         tail: Distance over which to smooth the tail.
         delta_r: Delta distance for 1st and 2nd derivative.
         n_interp: Number of total interpolation grid points for the tail.
@@ -459,68 +561,71 @@ class CubicSpline(Feed):
     Examples:
         >>> from tbmalt.common.maths.interpolation import CubicSpline
         >>> import torch
+        >>> from torch.nn import Parameter
         >>> x = torch.linspace(1, 10, 10)
-        >>> y = torch.sin(x)
+        >>> y = Parameter(torch.sin(x), requires_grad=False)
         >>> spline = CubicSpline(x, y)
         >>> spline.forward(torch.tensor([3.5]))
         >>> tensor([-0.3526])
         >>> torch.sin(torch.tensor([3.5]))
         >>> tensor([-0.3508])
 
-    TODO:
-        - Need to introduce method to switch gradient tracking on and off as a whole.
-
     """
 
-    def __init__(self, xx: Tensor, yy: Union[Tensor, Parameter], tail: Real = 1.0,
+    def __init__(self, x: Tensor, y: Parameter, tail: Real = 1.0,
                  delta_r: Real = 1E-5, n_interp: int = 8, **kwargs):
-        super(CubicSpline, self).__init__()
+        super().__init__()
 
         # X-knot values must be of an anticipated type
-        if not isinstance(xx, Tensor):
-            raise TypeError("The x-knot values must be either a `torch.Tensor`"
+        if not isinstance(x, Tensor):
+            raise TypeError("The x-knot values must be a `torch.Tensor`"
                             " instance.")
 
         # Same for the y-knot values
-        if not isinstance(yy, (Parameter, Tensor)):
+        if not isinstance(y, (Parameter, Tensor)):
             raise TypeError("The y-knot values must be either a `torch.Tensor`"
                             " or `torch.nn.Parameter` instance.")
 
-        assert yy.dim() <= 2, '"CubicSpline" only support 1D or 2D interpolation'
+        assert y.dim() <= 2, '"CubicSpline" only support 1D or 2D interpolation'
 
         # Ensure that there is not a mismatch between the number of x and y
         # points supplied: one-dimensional case only.
-        if yy.ndim == 1 and not (len(yy) == len(xx)):
+        if y.ndim == 1 and not (len(y) == len(x)):
             raise ValueError(
                 "Mismatch detected in the number of supplied `x` "
-                f"({len(xx)}) and `y` ({len(yy)}) values."
+                f"({len(x)}) and `y` ({len(y)}) values."
             )
 
         # This is just a repeat of the above check but for the two-dimensional
         # case.
-        elif yy.ndim == 2 and yy.shape[0] != len(xx):
+        elif y.ndim == 2 and y.shape[0] != len(x):
             raise ValueError(
                 f"Array shape mismatch detected, anticipated a `y` array of "
-                f"the shape ({len(xx)}, n), encountered {tuple(yy.shape)} instead."
+                f"the shape ({len(x)}, n), encountered {tuple(y.shape)} instead."
             )
 
         # Prevent users from unintentionally optimizing the knot locations.
-        if isinstance(xx, Parameter) or xx.requires_grad:
+        if isinstance(x, Parameter) or x.requires_grad:
             raise warnings.warn(
-                "Setting the knot positions 'xx' as a freely tunable parameter"
+                "Setting the knot positions 'x' as a freely tunable parameter"
                 " is strongly advised against as it may lead to instability or"
                 " incorrect behavior of the spline during optimisation."
-                " Please ensure that the `xx` argument is a `torch.tensor`"
+                " Please ensure that the `x` argument is a `torch.tensor`"
                 " type rather than a `torch.nn.Parameter` and that its"
                 "\"requires_grad\" attribute set to `False`.",
                 UserWarning, stacklevel=2)
 
         # Ensure that the y values are a parameter instance
-        if not isinstance(yy, Parameter):
-            yy = Parameter(yy, requires_grad=yy.requires_grad)
+        if not isinstance(y, Parameter):
+            warnings.warn(
+                "An instance of `torch.nn.Parameter` was expected for the "
+                "attribute `y`, but a `torch.Tensor` was received. The tensor "
+                "will be automatically cast to a parameter.",
+                UserWarning)
+            y = Parameter(y, requires_grad=y.requires_grad)
 
-        self.xp = xx
-        self._yp = yy
+        self.xp = x
+        self._y = y
 
         # Coefficients will be build when the `coefficients` property is
         # first invoked. Unless the user has supplied the spline coefficients
@@ -532,25 +637,25 @@ class CubicSpline(Feed):
                 DeprecationWarning, stacklevel=2)
             self._coefficients: Optional[Tensor] = kwargs.get("coefficients")
 
-        self.grid_step = xx[1] - xx[0]
+        self.grid_step = x[1] - x[0]
         self.delta_r = delta_r
         self.tail = tail
         self.n_interp = n_interp
 
         # Device type of the tensor in this class
-        self._device = xx.device
+        self._device = x.device
 
         # Store the version tracking information for the y-knot values so that
         # the coefficients can be updated as and when needed.
-        self._yp_version, self._yp_id = None, None
+        self._y_version, self._y_id = None, None
 
     @property
-    def yp(self) -> Parameter:
+    def y(self) -> Parameter:
         """Value of the spline at each grid point."""
-        return self._yp
+        return self._y
 
-    @yp.setter
-    def yp(self, value: Union[Parameter, Tensor]):
+    @y.setter
+    def y(self, value: Parameter):
         # Y-knot values must be of an anticipated type
         if not isinstance(value, (Parameter, Tensor)):
             raise TypeError("The y-knot values must be either a `torch.Tensor`"
@@ -558,10 +663,15 @@ class CubicSpline(Feed):
 
         # Ensure that the y values are a parameter instance
         if not isinstance(value, Parameter):
+            warnings.warn(
+                "An instance of `torch.nn.Parameter` was expected for the "
+                "attribute `y`, but a `torch.Tensor` was received. The tensor "
+                "will be automatically cast to a parameter.",
+                UserWarning)
             value = Parameter(value, requires_grad=value.requires_grad)
 
         # Finally, set new y-knot value tensor.
-        self._yp = value
+        self._y = value
 
     @property
     def coefficients(self):
@@ -574,7 +684,7 @@ class CubicSpline(Feed):
         # with the updated y-knot values.
         if self._knots_were_changed or self._coefficients is None:
 
-            ypt = bT(self._yp)
+            ypt = bT(self._y)
 
             # get the first dim of x
             nx = self.xp.shape[0]
@@ -629,7 +739,7 @@ class CubicSpline(Feed):
             f'input should not be less than {self.xp[0]}'
         n_grid_point = len(self.xp)
 
-        ypt = bT(self.yp)
+        ypt = bT(self.y)
 
         result = (
             torch.zeros(xnew.shape, device=self._device)
@@ -671,7 +781,7 @@ class CubicSpline(Feed):
 
     def __compute_tail_interpolation(self, xnew: Tensor, is_tail, r_max, result):
 
-        ypt = bT(self.yp)
+        ypt = bT(self.y)
 
         dr = xnew[is_tail] - r_max
         dr = dr.unsqueeze(-1) if ypt.dim() == 2 else dr
@@ -712,12 +822,12 @@ class CubicSpline(Feed):
         return interp.transpose(-1, 0) if interp.dim() > 1 else interp
 
     def _update_knot_version_tracking_data(self):
-        self._yp_version = self._yp._version
-        self._yp_id = id(self._yp)
+        self._y_version = self._y._version
+        self._y_id = id(self._y)
 
     @property
     def _knots_were_changed(self):
         """Check if the y-knot values have updated."""
-        ver_delta = self._yp_version != self._yp._version
-        id_delta = self._yp_id != id(self._yp)
+        ver_delta = self._y_version != self._y._version
+        id_delta = self._y_id != id(self._y)
         return ver_delta or id_delta

--- a/tbmalt/structures/orbitalinfo.py
+++ b/tbmalt/structures/orbitalinfo.py
@@ -499,7 +499,7 @@ class OrbitalInfo:
                 - "full": 1 matrix-element per orbital-orbital interaction.
                 - "shell": 1 matrix-element per shell-shell interaction block.
 
-                A more in-depth description of the this argument's effects is
+                A more in-depth description of this argument's effects is
                 given in :meth:`.azimuthal_matrix`. [DEFAULT="full"]
 
         Returns:
@@ -540,7 +540,7 @@ class OrbitalInfo:
                 - "shell": 1 matrix-element per shell-shell interaction block.
                 - "atomic": 1 matrix-element per atom-atom interaction block.
 
-                A more in-depth description of the this argument's effects is
+                A more in-depth description of this argument's effects is
                 given in :meth:`.azimuthal_matrix`. [DEFAULT="full"]
 
         Returns:
@@ -589,7 +589,7 @@ class OrbitalInfo:
                 - "shell": 1 matrix-element per shell-shell interaction block.
                 - "atomic": 1 matrix-element per atom-atom interaction block.
 
-                A more in-depth description of the this argument's effects is
+                A more in-depth description of this argument's effects is
                 given in :meth:`.azimuthal_matrix`. [DEFAULT="full"]
 
         Returns:

--- a/tests/unittests/test_dftb.py
+++ b/tests/unittests/test_dftb.py
@@ -7,6 +7,7 @@ from ase.build import molecule
 from tbmalt import Geometry, OrbitalInfo
 from tbmalt.physics.dftb import Dftb1, Dftb2
 from tbmalt.physics.dftb.feeds import SkFeed, SkfOccupationFeed, HubbardFeed
+from tbmalt.common.maths.interpolation import CubicSpline
 from tbmalt.common.batch import pack
 
 
@@ -43,9 +44,9 @@ def shell_resolved_feeds_scc(device, skf_file):
 def shell_resolved_feeds_scc_spline(device, skf_file):
     species = [1, 6, 8]
     h_feed = SkFeed.from_database(skf_file, species, 'hamiltonian',
-                                  interpolation='spline', device=device)
+                                  interpolation=CubicSpline, device=device)
     s_feed = SkFeed.from_database(skf_file, species, 'overlap',
-                                  interpolation='spline', device=device)
+                                  interpolation=CubicSpline, device=device)
     o_feed = SkfOccupationFeed.from_database(skf_file, species, device=device)
     u_feed = HubbardFeed.from_database(skf_file, species, device=device)
 

--- a/tests/unittests/test_dftb_feeds.py
+++ b/tests/unittests/test_dftb_feeds.py
@@ -2,14 +2,16 @@ import os
 from os.path import join, dirname
 import pytest
 import torch
-from torch.nn import Parameter, ParameterDict
-from typing import List
+from torch.nn import Parameter, ParameterDict, Module
+from typing import List, Type
 import numpy as np
 from ase.build import molecule
 
-from tbmalt.physics.dftb.feeds import ScipySkFeed, SkFeed, SkfOccupationFeed, HubbardFeed
+from tbmalt.physics.dftb.feeds import ScipySkFeed, SkFeed, SkfOccupationFeed, HubbardFeed, VcrSkFeed
 from tbmalt import Geometry, OrbitalInfo
 from tbmalt.common.batch import pack
+from tbmalt.common.maths.interpolation import CubicSpline, PolyInterpU
+from tbmalt.ml import Feed
 from functools import reduce
 
 torch.set_default_dtype(torch.float64)
@@ -146,110 +148,130 @@ def test_scipyskfeed_batch(device, skf_file: str):
 # Note that gradient tests are not performed on the ScipySkFeed as it is not
 # backpropagatable due to its use of Scipy splines for interpolation.
 
-def test_skfeed_poly_single(device, skf_file: str):
-    """SkFeed matrix single system operability tolerance test"""
-
-    b_def = {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]}
-    H_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'hamiltonian', 'polynomial', device=device)
-    S_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'overlap', 'polynomial', device=device)
-
-    for mol, H_ref, S_ref in zip(
-            molecules(device), hamiltonians(device), overlaps(device)):
-        H = H_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
-        S = S_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
-
-        check_1 = torch.allclose(H, H_ref, atol=1E-7)
-        check_2 = torch.allclose(S, S_ref, atol=1E-7)
-        check_3 = H.device == device
-
-        assert check_1, f'ScipySkFeed H matrix outside of tolerance ({mol})'
-        assert check_2, f'ScipySkFeed S matrix outside of tolerance ({mol})'
-        assert check_3, 'ScipySkFeed.matrix returned on incorrect device'
-
-
-def test_skfeed_poly_batch(device, skf_file: str):
-    """SkFeed matrix batch operability tolerance test"""
-
-    H_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'hamiltonian', 'polynomial', device=device)
-    S_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'overlap', 'polynomial', device=device)
-
-    mols = reduce(lambda i, j: i+j, molecules(device))
-    orbs = OrbitalInfo(mols.atomic_numbers,
-                        {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
-
-    H = H_feed.matrix(mols, orbs)
-    S = S_feed.matrix(mols, orbs)
-
-    check_1 = torch.allclose(H, pack(hamiltonians(device)), atol=1E-7)
-    check_2 = torch.allclose(S, pack(overlaps(device)), atol=1E-7)
-    check_3 = H.device == device
-
-    # Check that batches of size one do not cause problems
-    check_4 = (H_feed.matrix(mols[0:1], orbs[0:1]).ndim == 3)
-
-    assert check_1, 'ScipySkFeed H matrix outside of tolerance (batch)'
-    assert check_2, 'ScipySkFeed S matrix outside of tolerance (batch)'
-    assert check_3, 'ScipySkFeed.matrix returned on incorrect device'
-    assert check_4, 'Failure to operate on batches of size "one"'
-
-def test_skfeed_cubic_single(device, skf_file: str):
-    """SkFeed matrix single system operability tolerance test"""
-
-    b_def = {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]}
-    H_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'hamiltonian', 'spline', device=device)
-    S_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'overlap', 'spline', device=device)
-
-    for mol, H_ref, S_ref in zip(
-            molecules(device), hamiltonians(device), overlaps(device)):
-        H = H_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
-        S = S_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
-
-        check_1 = torch.allclose(H, H_ref, atol=1E-7)
-        check_2 = torch.allclose(S, S_ref, atol=1E-7)
-        check_3 = H.device == device
-
-        assert check_1, f'ScipySkFeed H matrix outside of tolerance ({mol})'
-        assert check_2, f'ScipySkFeed S matrix outside of tolerance ({mol})'
-        assert check_3, 'ScipySkFeed.matrix returned on incorrect device'
-
-
-def test_skfeed_cubic_batch(device, skf_file: str):
-    """SkFeed matrix batch operability tolerance test"""
-
-    H_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'hamiltonian', 'spline', device=device)
-    S_feed = SkFeed.from_database(
-        skf_file, [1, 6, 16, 79], 'overlap', 'spline', device=device)
-
-    mols = reduce(lambda i, j: i+j, molecules(device))
-    orbs = OrbitalInfo(mols.atomic_numbers,
-                        {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]})
-
-    H = H_feed.matrix(mols, orbs)
-    S = S_feed.matrix(mols, orbs)
-
-    check_1 = torch.allclose(H, pack(hamiltonians(device)), atol=1E-7)
-    check_2 = torch.allclose(S, pack(overlaps(device)), atol=1E-7)
-    check_3 = H.device == device
-
-    # Check that batches of size one do not cause problems
-    check_4 = (H_feed.matrix(mols[0:1], orbs[0:1]).ndim == 3)
-
-    assert check_1, 'ScipySkFeed H matrix outside of tolerance (batch)'
-    assert check_2, 'ScipySkFeed S matrix outside of tolerance (batch)'
-    assert check_3, 'ScipySkFeed.matrix returned on incorrect device'
-    assert check_4, 'Failure to operate on batches of size "one"'
-
-
 
 #########################################
-# tbmalt.physics.dftb.feeds.SkFeed #
+#   tbmalt.physics.dftb.feeds.SkFeed    #
+#########################################
+@pytest.mark.parametrize("interpolator", [PolyInterpU, CubicSpline])
+def test_skfeed_matrix_tolerance_single(
+        device, skf_file: str, interpolator: Type[Feed]):
+    """SkFeed feed matrix operability tolerance test, single system."""
+
+    def assert_matrix_close(matrix, ref_matrix, matrix_type, mol, interpolator_name):
+        """Helper to assert matrix closeness with a detailed message."""
+        assert torch.allclose(matrix, ref_matrix, atol=1E-7), (
+            f"SkFeed {matrix_type} matrix outside of tolerance for {mol} using {interpolator_name}:\n"
+            f"Max diff: {(matrix - ref_matrix).abs().max().item()}\n"
+            f"{matrix_type} shape: {matrix.shape}, ref shape: {ref_matrix.shape}\n"
+        )
+
+        # Check device consistency
+        assert matrix.device == device, (
+            f"SkFeed matrix returned on incorrect device:\n"
+            f"Expected: {device}, but got: {matrix.device}"
+        )
+
+    interpolator_name = interpolator.__class__.__name__
+    b_def = {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]}
+
+    H_feed = SkFeed.from_database(skf_file, list(b_def.keys()), 'hamiltonian',
+                                  interpolator, device=device)
+    S_feed = SkFeed.from_database(skf_file, list(b_def.keys()), 'overlap',
+                                  interpolator, device=device)
+
+    for mol, H_ref, S_ref in zip(molecules(device), hamiltonians(device), overlaps(device)):
+        orb_info = OrbitalInfo(mol.atomic_numbers, b_def)
+
+        H, S = H_feed.matrix(mol, orb_info), S_feed.matrix(mol, orb_info)
+
+        # Perform matrix checks using the helper function
+        assert_matrix_close(H, H_ref, 'H', mol, interpolator_name)
+        assert_matrix_close(S, S_ref, 'S', mol, interpolator_name)
+
+
+@pytest.mark.parametrize("interpolator", [PolyInterpU, CubicSpline])
+def test_skfeed_matrix_tolerance_batch(
+        device, skf_file: str, interpolator: Type[Feed]):
+    """SkFeed feed matrix operability tolerance test, batch system."""
+
+    def assert_matrix_close(matrix, ref_matrix, matrix_type, mol, interpolator_name):
+        """Helper to assert matrix closeness with a detailed message."""
+        assert torch.allclose(matrix, ref_matrix, atol=1E-7), (
+            f"SkFeed batch {matrix_type} matrix outside of tolerance for {mol} using {interpolator_name}:\n"
+            f"Max diff: {(matrix - ref_matrix).abs().max().item()}\n"
+            f"{matrix_type} shape: {matrix.shape}, ref shape: {ref_matrix.shape}\n"
+        )
+
+        assert matrix.device == device, (
+            f"SkFeed matrix returned on incorrect device:\n"
+            f"Expected: {device}, but got: {matrix.device}")
+
+    interpolator_name = interpolator.__class__.__name__
+    b_def = {1: [0], 6: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]}
+
+    mols = reduce(lambda i, j: i + j, molecules(device))
+    orbs = OrbitalInfo(mols.atomic_numbers, b_def)
+
+    H_feed = SkFeed.from_database(skf_file, list(b_def.keys()), 'hamiltonian',
+                                  interpolator, device=device)
+    S_feed = SkFeed.from_database(skf_file, list(b_def.keys()), 'overlap',
+                                  interpolator, device=device)
+
+    H = H_feed.matrix(mols, orbs)
+    S = S_feed.matrix(mols, orbs)
+
+    assert_matrix_close(H, pack(hamiltonians(device)), 'H', mols, interpolator_name)
+    assert_matrix_close(S, pack(overlaps(device)), 'S', mols, interpolator_name)
+
+    # Check that batches of size one do not cause problems
+    assert (H_feed.matrix(mols[0:1], orbs[0:1]).ndim == 3), (
+        "SkFeed failed when running on a batch of size one")
+
+
+@pytest.mark.parametrize("interpolator", [PolyInterpU, CubicSpline])
+def test_skfeed_requires_grad_settings(
+        device, skf_file: str, interpolator: Type[Feed]):
+    """Ensure `requires_grad` settings in `SkFeed.from_database` are respected."""
+
+    def all_params_require_grad(module: Module):
+        return all(param.requires_grad for param in module.parameters())
+
+    def no_params_require_grad(module: Module):
+        return not any(param.requires_grad for param in module.parameters())
+
+    args = (skf_file, [1, 6, 79], 'hamiltonian', interpolator)
+
+    # Test with requires_grad_onsite=True and requires_grad_offsite=False
+    feed = SkFeed.from_database(
+        *args, requires_grad_onsite=True, requires_grad_offsite=False)
+    onsite_grad_enabled = all_params_require_grad(feed.on_sites)
+    offsite_grad_disabled = no_params_require_grad(feed.off_sites)
+
+    # Test with requires_grad_onsite=False and requires_grad_offsite=True
+    feed = SkFeed.from_database(
+        *args, requires_grad_onsite=False, requires_grad_offsite=True)
+    onsite_grad_disabled = no_params_require_grad(feed.on_sites)
+    offsite_grad_enabled = all_params_require_grad(feed.off_sites)
+
+    # Assert that the requires_grad settings are correctly applied
+    assert onsite_grad_enabled and onsite_grad_disabled, (
+        "`requires_grad_onsite` setting not respected.")
+    assert offsite_grad_enabled and offsite_grad_disabled, (
+        "`requires_grad_offsite` setting not respected.")
+
+    # On-site terms for the overlap matrix are set to unity and are therefore
+    # not valid optimisation targets. Therefore, the `requires_grad_onsite`
+    # argument should not be respected when loading an overlap matrix
+    feed = SkFeed.from_database(
+        skf_file, [1, 6, 79], 'overlap', interpolator,
+        requires_grad_onsite=True)
+    onsite_grad_disabled_for_overlap = no_params_require_grad(feed.on_sites)
+
+    assert onsite_grad_disabled_for_overlap, (
+        "`requires_grad_onsite` setting should do be ignored for overlap.")
+
+#########################################
+#  tbmalt.physics.dftb.feeds.SkVcrFeed  #
 #########################################
 # Hamiltonian and overlap data for CH4 and H2O
 def reference_data(device):
@@ -340,8 +362,8 @@ def reference_data(device):
     return H_ref_ch4, S_ref_ch4, H_ref_h2o, S_ref_h2o
 
 
-def test_skfeed_single(device, skf_file_vcr):
-    """SkFeed matrix single system operability tolerance test"""
+def test_vcrskfeed_single(device, skf_file_vcr):
+    """VcrSkFeed matrix single system operability tolerance test"""
 
     H_ref_ch4, S_ref_ch4, H_ref_h2o, S_ref_h2o = reference_data(device)
 
@@ -349,10 +371,10 @@ def test_skfeed_single(device, skf_file_vcr):
     b_def = {1: [0], 6: [0, 1], 7: [0, 1], 8: [0, 1]}
 
     # Load the Hamiltonian, overlap feed model
-    h_feed = SkFeed.from_database(skf_file_vcr, species, 'hamiltonian',
-                                  interpolation='bicubic', device=device)
-    s_feed = SkFeed.from_database(skf_file_vcr, species, 'overlap',
-                                  interpolation='bicubic', device=device)
+    h_feed = VcrSkFeed.from_database(skf_file_vcr, species, 'hamiltonian',
+                                  device=device)
+    s_feed = VcrSkFeed.from_database(skf_file_vcr, species, 'overlap',
+                                     device=device)
 
     # Define (wave-function) compression radii, keep s and p the same
     vcrs = [torch.tensor([2.7, 2.5, 2.5, 2.5, 2.5], device=device),
@@ -362,8 +384,8 @@ def test_skfeed_single(device, skf_file_vcr):
 
     for ii, mol in enumerate([molecule('CH4'), molecule('H2O')]):
         mol = Geometry.from_ase_atoms(mol, device=device)
-        h_feed.vcr = vcrs[ii]
-        s_feed.vcr = vcrs[ii]
+        h_feed.compression_radii = vcrs[ii]
+        s_feed.compression_radii = vcrs[ii]
 
         H = h_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
         S = s_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
@@ -378,8 +400,8 @@ def test_skfeed_single(device, skf_file_vcr):
 
 
 # Batch
-def test_skfeed_batch(device, skf_file_vcr):
-    """SkFeed matrix batch system operability tolerance test"""
+def test_vcrskfeed_batch(device, skf_file_vcr):
+    """VcrSkFeed matrix batch system operability tolerance test"""
 
     H_ref_ch4, S_ref_ch4, H_ref_h2o, S_ref_h2o = reference_data(device)
 
@@ -388,10 +410,10 @@ def test_skfeed_batch(device, skf_file_vcr):
     b_def = {1: [0], 6: [0, 1], 7: [0, 1], 8: [0, 1]}
 
     # Load the Hamiltonian, overlap feed model
-    h_feed = SkFeed.from_database(skf_file_vcr, species, 'hamiltonian',
-                                  interpolation='bicubic', device=device)
-    s_feed = SkFeed.from_database(skf_file_vcr, species, 'overlap',
-                                  interpolation='bicubic', device=device)
+    h_feed = VcrSkFeed.from_database(skf_file_vcr, species, 'hamiltonian',
+                                  device=device)
+    s_feed = VcrSkFeed.from_database(skf_file_vcr, species, 'overlap',
+                                  device=device)
 
     # Define (wave-function) compression radii, keep s and p the same
     vcrs = torch.tensor([[2.7, 2.5, 2.5, 2.5, 2.5], [2.3, 2.5, 2.5, 0, 0]],
@@ -401,8 +423,8 @@ def test_skfeed_batch(device, skf_file_vcr):
 
     mol = Geometry.from_ase_atoms(
         [molecule('CH4'), molecule('H2O')], device=device)
-    h_feed.vcr = vcrs
-    s_feed.vcr = vcrs
+    h_feed.compression_radii = vcrs
+    s_feed.compression_radii = vcrs
 
     H = h_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
     S = s_feed.matrix(mol, OrbitalInfo(mol.atomic_numbers, b_def))
@@ -652,3 +674,4 @@ def test_hubbardfeed_batch(device, skf_file):
 
     check_2 = torch.allclose(predicted, reference)
     assert check_2, 'Predicted hubbard value errors exceed allowed tolerance'
+

--- a/tests/unittests/test_dftb_feeds_periodic.py
+++ b/tests/unittests/test_dftb_feeds_periodic.py
@@ -202,9 +202,14 @@ def test_scipyskfeed_pbc_batch(device, skf_file: str):
 # tbmalt.physics.dftb.feeds.SkFeed #
 #########################################
 
+
 # Single
 def test_skffeed_pbc_single(device, skf_file: str):
     """SkFeed matrix single system operability tolerance test"""
+
+    # Hmmmm... for some reason the tolerance checks pass when run via PyTest
+    # but fail if run manually.
+
     b_def = {1: [0], 6: [0, 1], 8: [0, 1], 16: [0, 1, 2], 79: [0, 1, 2]}
     H_feed = SkFeed.from_database(
         skf_file, [1, 6, 8, 16, 79], 'hamiltonian', device=device)
@@ -219,6 +224,7 @@ def test_skffeed_pbc_single(device, skf_file: str):
         check_1 = torch.allclose(H, H_ref, atol=1E-12)
         check_2 = torch.allclose(S, S_ref, atol=1E-12)
         check_3 = H.device == device
+
         assert check_1, f'SkFeed H matrix outside of tolerance ({sys})'
         assert check_2, f'SkFeed S matrix outside of tolerance ({sys})'
         assert check_3, 'SkFeed.matrix returned on incorrect device'
@@ -250,4 +256,3 @@ def test_skffeed_pbc_batch(device, skf_file: str):
     assert check_2, 'SkFeed S matrix outside of tolerance (batch)'
     assert check_3, 'SkFeed.matrix returned on incorrect device'
     assert check_4, 'Failure to operate on batches of size "one"'
-

--- a/tests/unittests/test_interpolation.py
+++ b/tests/unittests/test_interpolation.py
@@ -5,7 +5,7 @@ from torch.nn import Parameter
 from scipy.interpolate import CubicSpline as SciCubSpl
 import pytest
 from tests.test_utils import *
-from tbmalt.common.maths.interpolation import PolyInterpU, CubicSpline, BicubInterp
+from tbmalt.common.maths.interpolation import PolyInterpU, CubicSpline, BicubInterpSpl
 from tbmalt import Geometry, OrbitalInfo
 from tbmalt.common.batch import bT
 torch.set_default_dtype(torch.float64)
@@ -79,7 +79,7 @@ bi_data = torch.tensor([
 def test_bicubinterp_single(device):
     """Test single distances interpolation in Hamiltonian."""
     # 1. choose the distance 3.5 Bohr
-    bi_interp1 = BicubInterp(radii.to(device), bi_data[0].to(device))
+    bi_interp1 = BicubInterpSpl(radii.to(device), bi_data[0].to(device))
     data11 = bi_interp1(torch.tensor([3.75, 3.75], device=device))
     assert torch.abs(torch.tensor([-0.14372390269510], device=device)
                      - data11).lt(1e-3), 'tolerance error'
@@ -89,7 +89,7 @@ def test_bicubinterp_single(device):
                      - data12).lt(1e-3), 'tolerance error'
 
     # 1. choose the distance 7.0 Bohr
-    bi_interp2 = BicubInterp(radii.to(device), bi_data[1].to(device))
+    bi_interp2 = BicubInterpSpl(radii.to(device), bi_data[1].to(device))
     data21 = bi_interp2(torch.tensor([3.75, 3.75], device=device))
     assert torch.abs(torch.tensor([-0.00164882038419], device=device)
                      - data21).lt(1e-4), 'tolerance error'
@@ -101,7 +101,7 @@ def test_bicubinterp_single(device):
 
 def test_bicubinterp_batch(device):
     """Test batch distances interpolation in Hamiltonian."""
-    bi_interp = BicubInterp(radii.to(device), bi_data.to(device))
+    bi_interp = BicubInterpSpl(radii.to(device), bi_data.to(device))
     data = bi_interp(torch.tensor([[3.75, 3.75],
                                    [7.0, 7.0]], device=device))
     ref = torch.tensor([[-0.14372390269510, -0.00438283226086]], device=device)
@@ -112,7 +112,7 @@ def test_bicubinterp_batch(device):
 @pytest.mark.grad
 def test_bicubinterp_grad(device):
     """Gradient evaluation of BicubInterp interpolation."""
-    fit = BicubInterp(radii.to(device), bi_data[0].to(device))
+    fit = BicubInterpSpl(radii.to(device), bi_data[0].to(device))
     xi = torch.tensor([3.75, 3.75], requires_grad=True, device=device)
 
     grad_is_safe = gradcheck(fit, xi, raise_exception=False)
@@ -126,10 +126,12 @@ def test_bicubinterp_grad(device):
 def test_polyinterpu_single(device):
     """Test single distances interpolation in Hamiltonian."""
     xa = torch.linspace(0.2, 10, 50, device=device)
-    yb = torch.from_numpy(data[:, 9]).to(device)
+    yb = Parameter(
+        torch.from_numpy(data[:, 9]).to(device), requires_grad=False)
     ref = -2.7051061568285979E-002
     fit = PolyInterpU(xa, yb, n_interp=8, n_interp_r=4)
-    pred = fit(torch.tensor([4.3463697737315234], device=device))
+    pred = fit.forward(
+        torch.tensor([4.3463697737315234], device=device))
 
     assert abs(ref - pred) < 1E-14, 'tolerance check'
 
@@ -140,7 +142,8 @@ def test_polyinterpu_single(device):
     # Check n_interp
     ref2 = -2.705744877076714E-02
     fit.n_interp, fit.n_interp_r = 3, 2
-    pred = fit(torch.tensor([4.3463697737315234], device=device))
+    pred = fit.forward(
+        torch.tensor([4.3463697737315234], device=device))
 
     assert abs(ref2 - pred) < 1E-14, 'tolerance check'
 
@@ -148,9 +151,10 @@ def test_polyinterpu_single(device):
 def test_polyinterpu_batch(device):
     """Test multi distance interpolations in Hamiltonian."""
     xa = torch.linspace(0.2, 10, 50, device=device)
-    yb = torch.from_numpy(data[:, 9]).to(device)
+    yb = Parameter(
+        torch.from_numpy(data[:, 9]).to(device), requires_grad=False)
     fit = PolyInterpU(xa, yb)
-    pred = fit(torch.tensor(
+    pred = fit.forward(torch.tensor(
         [4.3463697737315234, 8.1258217508893704], device=device))
     ref = torch.tensor(
         [-2.7051061568285979E-002, -7.9892794322938818E-005], device=device)
@@ -165,7 +169,7 @@ def test_polyinterpu_batch(device):
     ref2 = torch.tensor(
         [-2.705744877076714E-02, -8.008294135339589E-05], device=device)
     fit.n_interp, fit.n_interp_r = 3, 2
-    pred = fit(torch.tensor(
+    pred = fit.forward(torch.tensor(
         [4.3463697737315234, 8.1258217508893704], device=device))
 
     assert (abs(ref2 - pred) < 1E-14).all(), 'tolerance check'
@@ -174,9 +178,11 @@ def test_polyinterpu_batch(device):
 def test_polyinterpu_tail(device):
     """Test the smooth Hamiltonian to zero code in the tail."""
     xa = torch.linspace(0.2, 10, 50, device=device)
-    yb = torch.from_numpy(data[:, 9]).to(device)
+    yb = Parameter(
+        torch.from_numpy(data[:, 9]).to(device), requires_grad=False)
     fit = PolyInterpU(xa, yb)
-    pred = fit(torch.tensor([10.015547739468293], device=device))
+    pred = fit.forward(torch.tensor(
+        [10.015547739468293], device=device))
     ref = torch.tensor([1.2296664801642019E-005], device=device)
 
     assert (abs(ref - pred) < 1E-11).all(), 'tolerance check'
@@ -187,30 +193,35 @@ def test_polyinterpu_tail(device):
 
     # Check tail
     fit.tail = 0.6
-    pred2 = fit(torch.tensor([10.015547739468293], device=device))
+    pred2 = fit.forward(
+        torch.tensor([10.015547739468293], device=device))
     ref2 = torch.tensor([9.760620707717307E-06], device=device)
 
     assert (abs(ref2 - pred2) < 1E-11).all(), 'tolerance check'
 
     # Check delta_r
     fit.tail, fit.delta_r = 1.0, 1E-4
-    pred3 = fit(torch.tensor([10.015547739468293], device=device))
+    pred3 = fit.forward(
+        torch.tensor([10.015547739468293], device=device))
     ref3 = torch.tensor([1.229666474639370E-05], device=device)
 
     assert (abs(ref3 - pred3) < 1E-13).all(), 'tolerance check'
 
-
 @pytest.mark.grad
 def test_polyinterpu_grad(device):
     """Gradient evaluation of polynomial interpolation."""
-    x = torch.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.],
-                     device=device)
-    y = torch.rand(10, device=device)
-    fit = PolyInterpU(x, y)
-    xi = torch.tensor([0.6], requires_grad=True, device=device)
-    grad_is_safe = gradcheck(fit, xi, raise_exception=False)
 
-    assert grad_is_safe, 'Gradient stability test'
+    x_knots = torch.linspace(0.2, 10, 50, device=device)
+    x_target = torch.tensor([0.6], device=device)
+    spline_proxy = lambda y: PolyInterpU(x_knots, y).forward(x_target)
+
+    y_knots = Parameter(torch.from_numpy(data[:, 9]).to(device))
+    grad_is_safe = gradcheck(spline_proxy, y_knots, raise_exception=False)
+    assert grad_is_safe, 'Gradient stability test failed'
+
+    y_knots = Parameter(torch.from_numpy(data[:, [9, 19]]).to(device))
+    grad_is_safe = gradcheck(spline_proxy, y_knots, raise_exception=False)
+    assert grad_is_safe, 'Gradient stability test failed'
 
 
 ###################################


### PR DESCRIPTION
This pull request updates the `SkFeed` class to bring it into line with expected `Feed` behaviour. Note that the variable compression radius variant has not been fully integrated and has many rough edges at this point in time.

- Divided the Slater-Koster feed class "`SkFeed`" into a standard version, `SkFeed`, and a variable compression radius variant, `VcrSkFeed`.
- Updated `SkFeed` class to bring it into line with expected `Feed`/`Module` behaviour.
- `PolyInterpU` class modified to better align with the feed framework.
- Interpolation value attribute of the `PolyInterpU` and `CubicSpline` classes renamed to `y` to make the field more intelligible (useful when invoking `Model.named_parameters()`).
