### PR TITLE
Resolved `PolyInterpU` performance bottleneck

### DIFF
--- a/tbmalt/common/maths/interpolation.py
+++ b/tbmalt/common/maths/interpolation.py
@@ -388,8 +388,11 @@ class PolyInterpU(Feed):
             xa = self._x[0] + (ind_last.unsqueeze(1) - self.n_interp - 1 +
                                torch.arange(self.n_interp, device=self._device)
                                ) * grid_step
-            yb = torch.stack([self._y[ii - self.n_interp - 1: ii - 1]
-                              for ii in ind_last]).to(self._device)
+
+            start_idx = (ind_last - self.n_interp - 1)
+            idx_matrix = start_idx.unsqueeze(-1) + torch.arange(
+                self.n_interp, device=self.device)
+            yb = self._y[idx_matrix]
 
             result[_mask] = poly_interp(xa, yb, rr[_mask])
 


### PR DESCRIPTION
This commit request resolves a significant performance bottleneck in the `PolyInterpU.forward` method arising form the manner in which the indexing tensor was constructed. This fix results in an 84% reduction in the time required to construct the Hamiltonian matrix for a batch of 2000 C2H2Au2S3 systems when using the `SkFeed` with the `PolyInterpU` interpolator. 