### PR TITLE
Argument to suppress SCF error doesn't do anything due to typo

### DIFF
--- a/tbmalt/physics/dftb/__init__.py
+++ b/tbmalt/physics/dftb/__init__.py
@@ -644,7 +644,7 @@ class Dftb2(Calculator):
             None: None
         }[filling_scheme]
         self.max_scc_iter = max_scc_iter
-        self.suppress_SCF_error = kwargs.get('supress_SCF_error', False)
+        self.suppress_SCF_error = kwargs.get('suppress_SCF_error', False)
         self.gamma_scheme = kwargs.get('gamma_scheme', 'exponential')
         self.coulomb_scheme = kwargs.get('coulomb_scheme', 'search')
 


### PR DESCRIPTION
The Dftb2 calculator has an optional argument, listed in the documentation as "suppress_SCF_error". However, giving a keyword argument of that name doesn't do anything. As an example, after the necessary preliminaries, this code:

```
dftb_calculator = Dftb2(h_feed, s_feed, o_feed, u_feed, r_feed, suppress_SCF_error = True)
    
print('Suppress SCF error setting:')    
print(dftb_calculator.suppress_SCF_error)    
    
# Setting suppress_SCF_error directly    
dftb_calculator.suppress_SCF_error = True    
    
print('New suppress SCF error setting:')    
print(dftb_calculator.suppress_SCF_error)
```

Produces this output:

```
Suppress SCF error setting:
False
New suppress SCF error setting:
True
```

The reason seems to be this line:

```
self.suppress_SCF_error = kwargs.get('supress_SCF_error', False)
```

See the typo?

After correcting that, the example code above gives the expected output:

```
Suppress SCF error setting:
True
New suppress SCF error setting:
True
```