### PR TITLE
Make energy differentiable wrt positions by cloning the distance matrix before masking

### DIFF
--- a/tbmalt/structures/geometry.py
+++ b/tbmalt/structures/geometry.py
@@ -271,8 +271,10 @@ class Geometry:
         """Distance matrix between atoms in the system."""
         # Todo: Modify to account for PBC
 
-        dist = torch.cdist(self.positions, self.positions, p=2)
+        dist_raw = torch.cdist(self.positions, self.positions, p=2)
         # Ensure padding area is zeroed out
+        # But don't modify in place
+        dist = dist_raw.clone()
         dist[self._mask_dist] = 0
 
         # cdist bug, sometimes distances diagonal is not zero


### PR DESCRIPTION
This is a change to make it possible to calculate "forces" by differentiating with respect to geometries.

For example:

```
# Run the DFTB calculation
dftb_calculator(geometries, orbs)
# Force on all of the atoms    
# First, compute the sum of the energies across all the molecules    
# This is not the energy of any particular molecule, it's an artificial sum
# across a batch
total_energy = predicted_energy_uncorrected.sum()
# Then, differentiate this total with respect to all the positions in the batch
# Because the energy of a molecule does not depend on the positions of other
# molecules, this is the same as differentiating individual energies with
# respect to the positions
# I really don't know why it returns a tuple, but there's only one element
# in it, so unwrapping it
dEpdr, = torch.autograd.grad(total_energy, geometries.positions)
# Forces for all atoms, not just in one particular molecule
# Force is negative derivative of energy, points down energy surface
all_force_vecs_raw = -dEpdr
```

Adam has explained to me that these "forces" aren't really accurate, since they only include one SCC cycle, and in fact they do not seem to be accurate in my tests.

However, if you want to be able to differentiate with respect to geometries, this makes it possible.

I can think of two arguments against incorporating this change:

* By cloning the distance matrix, I may be using more memory. It may be better to make this optional, or to look for a more clever solution that doesn't involve cloning.
* I'm not sure how this interacts with the force calculation methods in https://github.com/jonmue42/tbmalt/tree/ana_forces which seems to not make any changes like mine to geometry.py. I would be interested in any comments on this.

However, if differentiating with respect to geometry is "supposed" to just work, then this is an easy fix to enable it.