### PR TITLE
Bug fix for wrong indexing of the segments in the CubicSpline

### DIFF
--- a/tbmalt/common/maths/interpolation.py
+++ b/tbmalt/common/maths/interpolation.py
@@ -734,9 +734,9 @@ class CubicSpline(Feed):
         # interpolation of xx which not in the tail
         if interpolate.any():
             # get the nearest grid point index of distance in grid points
-            ind = torch.round(
+            ind = torch.floor(
                 ((xnew - self.xp[0]) / self.grid_step)).detach().long()
-            ind = ind[interpolate] - 1
+            ind = ind[interpolate]
             dx = xnew[interpolate] - self.xp[ind]
             aa, bb, cc, dd = self.coefficients[..., ind]
             interp = aa + bb * dx + cc * dx**2 + dd * dx**3


### PR DESCRIPTION
Fixes bug in the CubicSpline forward.
Before, the use torch.round() resulted into segmentation of the Splines in the middle of the interpolation points and also lead to an additional spline for values < 0.5.

Changed torch.round() to torch.floor(), so the values are always rounded down.
This also fixes a bug, where changing the y-knot values lead to discontinuities.