### PR TITLE
docs: fixed documentation build bug

### DIFF
--- a/docs/source/_templates/class.rst
+++ b/docs/source/_templates/class.rst
@@ -6,26 +6,20 @@
    :members:
    :show-inheritance:
    :inherited-members:
-   :special-members:
+   :member-order: groupwise
+   :exclude-members: {{ attributes|join(', ') }}
 
-   {% block attributes %}
    {% if attributes %}
-   .. rubric:: {{ _('Properties') }}
+   .. rubric:: Attributes and Properties
 
    .. autosummary::
    {% for item in attributes %}
       ~{{ name }}.{{ item }}
-   {%- endfor %}
-   {% endif %}
-   {% endblock %}
+   {% endfor %}
 
-   {% block methods %}
+   {% endif %}
+
    {% if methods %}
-   .. rubric:: {{ _('Methods') }}
+   .. rubric:: Methods
 
-   .. autosummary::
-   {% for item in methods %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
    {% endif %}
-   {% endblock %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,9 +48,9 @@ extensions = [
 
 add_module_names = False
 
-set_type_checking_flag = False
+set_type_checking_flag = True
 typehints_fully_qualified = False
-always_document_param_types = False
+always_document_param_types = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -81,25 +81,6 @@ autosummary_mock_imports = [
 autosummary_generate = True
 
 
-
-# Autosummary ignores requests to not document the class __init__ method. Thus
-# it must be done manually via a autodoc-skip-member hook. However this results
-# in it ignoring requests to not document special & private methods. Hence, an
-# ugly hack is needed.
-
-permitted_specials = ['__call__']
-
-
-def skip(app, what, name, obj, would_skip, options):
-    if name.startswith(('__', '_')) and name not in permitted_specials:
-        return True
-    else:
-        return would_skip
-
-
-def setup(app):
-    app.connect("autodoc-skip-member", skip)
-
 # -- Napoleon configuration settings -----------------------------------------
 
 napoleon_google_docstring = True
@@ -122,6 +103,11 @@ napoleon_custom_sections = None
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+    'collapse_navigation': True,
+    'navigation_depth': 4
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ tight binding theory....
 
 .. toctree::
    :numbered:
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Table of Contents
    :name: mastertoc
 

--- a/tbmalt/common/maths/interpolation.py
+++ b/tbmalt/common/maths/interpolation.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Interpolation for general purpose."""
-from typing import Tuple, Union, Optional
+"""General purpose interpolation methods."""
+from typing import Optional
 from numbers import Real
 import warnings
 import torch
@@ -43,8 +43,6 @@ class BicubInterpSpl(Feed):
         >>> plt.plot(x, z.diagonal(), 'ro-', xnew, znew, 'b-')
         >>> plt.show()
 
-    References:
-        .. [wiki] https://en.wikipedia.org/wiki/Bicubic_interpolation
 
     """
 
@@ -213,14 +211,13 @@ class PolyInterpU(Feed):
         x: Grid points for interpolation, 1D Tensor.
         y: Values to be interpolated at each grid point. Note that this must
             be a `torch.nn.Parameter` rather than a standard torch `Tensor`.
-        tail: Distance to smooth the tail.
-        delta_r: Delta distance for 1st, 2nd derivative.
-        n_interp: Number of total interpolation grid points.
-        n_interp_r: Number of right side interpolation grid points.
+        tail: Distance to smooth the tail. [DEFAULT=1.0]
+        delta_r: Delta distance for 1st, 2nd derivative. [DEFAULT=1E-5]
+        n_interp: Number of total interpolation grid points. [DEFAULT=8]
+        n_interp_r: Number of right side interpolation grid points. [DEFAULT=4]
 
     Attributes:
         delta_r: Delta distance for 1st, 2nd derivative.
-        tail: Distance to smooth the tail.
         n_interp: Number of total interpolation grid points.
         n_interp_r: Number of right side interpolation grid points.
 
@@ -241,8 +238,8 @@ class PolyInterpU(Feed):
         >>> poly = PolyInterpU(x, y, n_interp=8, n_interp_r=4)
         >>> new_x = torch.rand(10) * 2. * torch.pi
         >>> new_y = poly(new_x)
-        >>> plt.plot(x, y, 'k-')
-        >>> plt.plot(new_x, new_y, 'rx')
+        >>> plt.plot(x.numpy(), y.detach().numpy(), 'k-')
+        >>> plt.plot(new_x.numpy(), new_y.numpy(), 'rx')
         >>> plt.show()
 
     """
@@ -526,9 +523,6 @@ class CubicSpline(Feed):
 
     Keyword Args:
         coefficients: 0th, 1st, 2nd and 3rd order parameters in cubic spline.
-
-    References:
-        .. [csi_wiki] https://en.wikipedia.org/wiki/Spline_(mathematics)
 
     Examples:
         >>> from tbmalt.common.maths.interpolation import CubicSpline

--- a/tbmalt/io/xtb/__init__.py
+++ b/tbmalt/io/xtb/__init__.py
@@ -1,4 +1,4 @@
-# This file is part of tbmalt.
+#Tuple, Union,  This file is part of tbmalt.
 # SPDX-Identifier: LGPL-3.0-or-later
 """
 This module defines the parametrization of the extended tight-binding Hamiltonian.

--- a/tbmalt/ml/__init__.py
+++ b/tbmalt/ml/__init__.py
@@ -5,7 +5,7 @@ The primary machine learning components of TBMaLT are located within this
 module.
 """
 import torch
-from abc import ABC, abstractmethod
+from abc import ABC
 
 
 class Feed(torch.nn.Module, ABC):
@@ -26,6 +26,7 @@ class Feed(torch.nn.Module, ABC):
     quantum mechanical solvers.
 
     Key Features:
+
     - Automatic tracking of optimisable parameters, facilitating integration
       with PyTorch's optimization routines.
     - Support for nested `Feed` objects, allowing for the construction of

--- a/tbmalt/ml/acsf.py
+++ b/tbmalt/ml/acsf.py
@@ -13,7 +13,7 @@ from tbmalt.ml import Feed
 
 
 class Acsf(Feed):
-    """Construct Atom-centered symmetry functions (Acsf).
+    """Construct Atom-centered symmetry functions (ACSF).
 
     This class is designed for batch calculations. Single geometry will be
     transferred to batch in the beginning.
@@ -41,12 +41,15 @@ class Acsf(Feed):
         >>> geo = Geometry.from_ase_atoms(ch4)
         >>> species = geo.chemical_symbols
         >>> acsf = Acsf(geo, g1_params=rcut, g4_params=torch.tensor(
-        [[0.02, 1.0, -1.0]]), element_resolve=True, atom_like=False)
+        ...             [[0.02, 1.0, -1.0]]), element_resolve=True,
+        ...             atom_like=False)
         >>> g = acsf()
 
+    Notes:
+        For more information reguarding ACSF's see [Behler2011]_.
 
     References:
-        .. [ACSF] Jörg Behler. Atom-centered symmetry functions for constructing
+        .. [Behler2011] Jörg Behler. Atom-centered symmetry functions for constructing
                   high-dimensional neural network potentials. J. Chem. Phys.,
                   134(7):074106, 2011.
 

--- a/tbmalt/ml/calculator.py
+++ b/tbmalt/ml/calculator.py
@@ -1,4 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Calculator module.
 
+This module defines the abstract base class ``Calculator`` upon which all
+calculator instances are based. Calculator instances, such as ``Dftb2`` play
+a foundational roll within TBMaLT.
+"""
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any
 import torch
@@ -57,9 +63,11 @@ class Calculator(Module, ABC):
         pass
 
     def cache(self) -> Dict[str, Any]:
-        """
+        """Return a cache for bootstrapping subsequent calculations.
+
         This returns a cache that may be fed into the next call to bootstrap the
         startup. This is only meaningful when restarting a calculation on a
         system after the calculator has been reset.
         """
-        pass
+        raise NotImplementedError(
+            "Abstract method has not been implemented for this class.")

--- a/tbmalt/ml/loss_function.py
+++ b/tbmalt/ml/loss_function.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+"""Loss module.
+
+The loss module is intended to house all the components necessary to define
+a loss metric to be used when optimising a model.
+"""
+
 from tbmalt.ml.calculator import Calculator
 import tbmalt.common.maths as tb_math
 from typing import Callable, Optional, Union, Any, Dict, Tuple
@@ -20,7 +27,7 @@ def l1_loss(prediction: Tensor, reference: Tensor, weights: Optional[Tensor] = N
     """
     Calculates the L1 loss (also known as absolute error) between the prediction and the reference.
 
-    Args:
+    Arguments:
     - prediction (torch.Tensor): The predicted values.
     - reference (torch.Tensor): The actual values to compare against.
     - weights (torch.Tensor): weights for each system [Optional].

--- a/tbmalt/physics/dftb/feeds.py
+++ b/tbmalt/physics/dftb/feeds.py
@@ -424,22 +424,18 @@ class ScipySkFeed(IntegralFeed):
             >>> from ase.build import molecule
             >>> import torch
             >>> torch.set_default_dtype(torch.float64)
-
-            # Download the auorg-1-1 parameter set
+            >>> # Download the auorg-1-1 parameter set
             >>> url = 'https://github.com/dftbparams/auorg/releases/download/v1.1.0/auorg-1-1.tar.xz'
             >>> path = "auorg.h5"
             >>> download_dftb_parameter_set(url, path)
-
-            # Preparation of system to calculate
+            >>> # Preparation of system to calculate
             >>> geo = Geometry.from_ase_atoms(molecule('H2'))
             >>> orbs = OrbitalInfo(geo.atomic_numbers,
-                                     shell_dict={1: [0]})
-
-            # Definition of feeds
+            ...                    shell_dict={1: [0]})
+            >>> # Definition of feeds
             >>> h_feed = ScipySkFeed.from_database(path, [1], 'hamiltonian')
             >>> s_feed = ScipySkFeed.from_database(path, [1], 'overlap')
-
-            # Matrix elements
+            >>> # Matrix elements
             >>> H = h_feed.matrix(geo, orbs)
             >>> S = s_feed.matrix(geo, orbs)
             >>> print(H)
@@ -948,40 +944,22 @@ class SkFeed(IntegralFeed):
         Examples:
             >>> from tbmalt import OrbitalInfo, Geometry
             >>> from tbmalt.physics.dftb.feeds import SkFeed
-            >>> from tbmalt.io.skf import Skf
+            >>> from tbmalt.tools.downloaders import download_dftb_parameter_set
             >>> from ase.build import molecule
-            >>> import urllib
-            >>> import tarfile
-            >>> from os.path import join
             >>> import torch
             >>> torch.set_default_dtype(torch.float64)
-
-            # Link to the auorg-1-1 parameter set
-            >>> link = 'https://github.com/dftbparams/auorg/releases/download/v1.1.0/auorg-1-1.tar.xz'
-
-            # Preparation of sk file
-            >>> elements = ['H', 'C', 'O', 'Au', 'S']
-            >>> tmpdir = './'
-            >>> urllib.request.urlretrieve(
-            ...     link, path := join(tmpdir, 'auorg-1-1.tar.xz'))
-            >>> with tarfile.open(path) as tar:
-            ...     tar.extractall(tmpdir)
-            >>> skf_files = [join(tmpdir, 'auorg-1-1', f'{i}-{j}.skf')
-            ...              for i in elements for j in elements]
-            >>> for skf_file in skf_files:
-            ...     Skf.read(skf_file).write(path := join(tmpdir,
-            ...                                           'auorg.hdf5'))
-
-            # Preparation of system to calculate
+            >>>
+            >>> # Download auorg-1-1 parameter set
+            >>> url = 'https://github.com/dftbparams/auorg/releases/download/v1.1.0/auorg-1-1.tar.xz'
+            >>> path = "auorg.h5"
+            >>> download_dftb_parameter_set(url, path)
+            >>> # Specify target system
             >>> geo = Geometry.from_ase_atoms(molecule('H2'))
-            >>> orbs = OrbitalInfo(geo.atomic_numbers,
-            ...                    shell_dict={1: [0]})
-
-            # Definition of feeds
+            >>> orbs = OrbitalInfo(geo.atomic_numbers, shell_dict={1: [0]})
+            >>> # Define feeds
             >>> h_feed = SkFeed.from_database(path, [1], 'hamiltonian')
             >>> s_feed = SkFeed.from_database(path, [1], 'overlap')
-
-            # Matrix elements
+            >>> # Construct Hamiltonian and overlap matrices
             >>> H = h_feed.matrix(geo, orbs)
             >>> S = s_feed.matrix(geo, orbs)
             >>> print(H)
@@ -990,6 +968,7 @@ class SkFeed(IntegralFeed):
             >>> print(S)
             tensor([[1.0000, 0.6433],
                     [0.6433, 1.0000]])
+
 
         """
         # As C-H & C-H interactions are the same only one needs to be loaded.
@@ -1711,18 +1690,16 @@ class SkfOccupationFeed(Feed):
             >>> from tbmalt.physics.dftb.feeds import SkfOccupationFeed
             >>> from tbmalt.tools.downloaders import download_dftb_parameter_set
             >>> torch.set_default_dtype(torch.float64)
-
-            # Download the auorg-1-1 parameter set
+            >>>
+            >>> # Download the auorg-1-1 parameter set
             >>> url = 'https://github.com/dftbparams/auorg/releases/download/v1.1.0/auorg-1-1.tar.xz'
             >>> path = "auorg.h5"
             >>> download_dftb_parameter_set(url, path)
-
-            # Definition of feeds
+            >>> # Definition of feeds
             >>> o_feed = SkfOccupationFeed.from_database(path, [1, 6])
             >>> shell_dict = {1: [0], 6: [0, 1]}
-
-            # Occupancy information of an example system
-            >>> o_feed(OrbitalInfo(torch.tensor([6, 1, 1, 1, 1]), shell_dict))
+            >>> # Occupancy information of an example system
+            >>> print(o_feed(OrbitalInfo(torch.tensor([6, 1, 1, 1, 1]), shell_dict)))
             tensor([2.0000, 0.6667, 0.6667, 0.6667,
                     1.0000, 1.0000, 1.0000, 1.0000])
 
@@ -1881,20 +1858,17 @@ class HubbardFeed(Feed):
             >>> import torch
             >>> from tbmalt import OrbitalInfo
             >>> from tbmalt.physics.dftb.feeds import HubbardFeed
-            from tbmalt.tools.downloaders import download_dftb_parameter_set
+            >>> from tbmalt.tools.downloaders import download_dftb_parameter_set
             >>> torch.set_default_dtype(torch.float64)
-
-            # Download the auorg-1-1 parameter set
+            >>> # Download the auorg-1-1 parameter set
             >>> url = 'https://github.com/dftbparams/auorg/releases/download/v1.1.0/auorg-1-1.tar.xz'
             >>> path = "auorg.h5"
             >>> download_dftb_parameter_set(url, path)
-
-            # Definition of feeds
+            >>> # Definition of feeds
             >>> u_feed = HubbardFeed.from_database(path, [1, 6])
             >>> shell_dict = {1: [0], 6: [0, 1]}
-
-            # Hubbard U values of an example system
-            >>> u_feed(OrbitalInfo(torch.tensor([6, 1, 1, 1, 1]), shell_dict))
+            >>> # Hubbard U values of an example system
+            >>> print(u_feed(OrbitalInfo(torch.tensor([6, 1, 1, 1, 1]), shell_dict)))
             tensor([0.3647, 0.4196, 0.4196, 0.4196, 0.4196])
 
         """
@@ -1921,15 +1895,21 @@ class DftbpRepulsiveSpline(Feed):
     only within the specified cutoff radius, being zero beyond this distance.
 
     1. **Short-range exponential head** when distances ≤ first grid point:
+
        .. math::
+
            e^{-a_{1} r + a_{2}} + a_{3}
 
     2. **Intermediate cubic spline body** defined on each interval [r_i, r_{i+1}]:
+
        .. math::
+
            c_{0} + c_{1}(r - r_{0}) + c_{2}(r - r_{0})^{2} + c_{3}(r - r_{0})^{3}
 
     3. **Long-range polynomial tail** between the last spline point and cutoff:
+
        .. math::
+
            c_{0} + c_{1}(r - r_{n}) + c_{2}(r - r_{n})^{2}
            + c_{3}(r - r_{n})^{3} + c_{4}(r - r_{n})^{4} + c_{5}(r - r_{n})^{5}
 

--- a/tbmalt/physics/dftb/gamma.py
+++ b/tbmalt/physics/dftb/gamma.py
@@ -19,8 +19,8 @@ def gamma_exponential(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
             be constructed.
         orbs: `OrbitalInfo` instance associated with the target system.
         hubbard_Us: Hubbard U values. one value should be specified for each
-            atom or shell depending if the calculation being performed is atom
-            or shell resolved.
+            atom or shell depending on if the calculation being performed is
+            atom or shell resolved.
 
     Returns:
         gamma: gamma matrix.
@@ -29,14 +29,13 @@ def gamma_exponential(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
         >>> from tbmalt import OrbitalInfo, Geometry
         >>> from tbmalt.physics.dftb.gamma import gamma_exponential
         >>> from ase.build import molecule
-
-        # Preparation of system to calculate
+        >>>
+        >>> # Preparation of system to calculate
         >>> geo = Geometry.from_ase_atoms(molecule('CH4'))
         >>> orbs = OrbitalInfo(geo.atomic_numbers,
-                               shell_dict= {1: [0], 6: [0, 1]})
+        ...                    shell_dict= {1: [0], 6: [0, 1]})
         >>> hubbard_U = torch.tensor([0.3647, 0.4196, 0.4196, 0.4196, 0.4196])
-
-        # Build the gamma matrix
+        >>> # Build the gamma matrix
         >>> gamma = gamma_exponential(geo, orbs, hubbard_U)
         >>> print(gamma)
         tensor([[0.3647, 0.3234, 0.3234, 0.3234, 0.3234],
@@ -136,20 +135,21 @@ def gamma_gaussian(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
 
     Elements of the gamma matrix are calculated via the following equation:
 
-    .. math::
+        .. math::
 
-        \gamma_{ij}(R_{ij}) = \frac{\text{erf}(C_{ij}R_{ij})}{R_{ij}}
+            \gamma_{ij}(R_{ij}) = \frac{\text{erf}(C_{ij}R_{ij})}{R_{ij}}
 
     Where the coefficients :math:`C` are calculated as
 
-    .. math::
+        .. math::
 
-        C_{ij} = \sqrt{\frac{4\ln{2}}{\text{FWHM}_{i}^2 + \text{FWHM}_{j}^2}}
+            C_{ij} = \sqrt{\frac{4\ln{2}}{\text{FWHM}_{i}^2 + \text{FWHM}_{j}^2}}
 
     and the full width half max values, FWHM, like so
 
-    .. math::
-        \text{FWHM}_{i} = \sqrt{\frac{8\ln{2}}{\pi}}\frac{1}{U_i}
+        .. math::
+
+            \text{FWHM}_{i} = \sqrt{\frac{8\ln{2}}{\pi}}\frac{1}{U_i}
 
     Where U and R are the hubbard U and distance values respectively.
 
@@ -170,7 +170,7 @@ def gamma_gaussian(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
         Note that this must be consistent with the `shell_resolved` attribute
         of the supplied `OrbitalInfo` instance ``orbs``.
 
-        Currently the Hubbard U values must be specified manually, however the
+        Currently, the Hubbard U values must be specified manually, however the
         option to supply a feed object will be added at a later data. This will
         facilitate the automated construction of the Hubbard U tensor and shall
         permit the use of environmentally dependent U values if desired.
@@ -179,14 +179,13 @@ def gamma_gaussian(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
         >>> from tbmalt import OrbitalInfo, Geometry
         >>> from tbmalt.physics.dftb.gamma import gamma_gaussian
         >>> from ase.build import molecule
-
-        # Preparation of system to calculate
+        >>>
+        >>> # Preparation of system to calculate
         >>> geo = Geometry.from_ase_atoms(molecule('CH4'))
         >>> orbs = OrbitalInfo(geo.atomic_numbers,
-                               shell_dict= {1: [0], 6: [0, 1]})
+        ...                    shell_dict= {1: [0], 6: [0, 1]})
         >>> hubbard_U = torch.tensor([0.3647, 0.4196, 0.4196, 0.4196, 0.4196])
-
-        # Build the gamma matrix
+        >>> # Build the gamma matrix
         >>> gamma = gamma_gaussian(geo, orbs, hubbard_U)
         >>> print(gamma)
         tensor([[0.3647, 0.3326, 0.3326, 0.3326, 0.3326],
@@ -286,22 +285,20 @@ def gamma_exponential_pbc(geometry: Geometry, orbs: OrbitalInfo,
     Examples:
         >>> from tbmalt import OrbitalInfo, Geometry
         >>> from tbmalt.physics.dftb.gamma import gamma_exponential_pbc
-
-        # Preparation of system to calculate
+        >>>
+        >>> # Preparation of system to calculate
         >>> cell = torch.tensor([[2., 0., 0.], [0., 4., 0.], [0., 0., 2.]])
         >>> pos = torch.tensor([[0., 0., 0.], [0., 2., 0.]])
         >>> num = torch.tensor([1, 1])
         >>> cutoff = torch.tensor([9.98])
         >>> geo = Geometry(num, pos, cell, units='a', cutoff=cutoff)
         >>> orbs = OrbitalInfo(geo.atomic_numbers,
-                               shell_dict= {1: [0]})
+        ...                    shell_dict= {1: [0]})
         >>> hubbard_U = torch.tensor([0.4196, 0.4196])
-
-        # 1/R matrix.calculated from coulomb module
+        >>> # 1/R matrix, normally calculated by the coulomb module
         >>> invr = torch.tensor([[-0.4778, -0.2729],
-                                 [-0.2729, -0.4778]])
-
-        # Build the gamma matrix
+        ...                      [-0.2729, -0.4778]])
+        >>> # Build the gamma matrix
         >>> gamma = gamma_exponential_pbc(geo, orbs, invr, hubbard_U)
         >>> print(gamma)
         tensor([[-0.1546, -0.3473],
@@ -407,9 +404,8 @@ def _expgamma_cutoff(alpha: Tensor, beta: Tensor, gamma_tem: Tensor,
         >>> ua = torch.tensor([0.3647, 0.4196]) # Hubbard U values of C, H
         >>> ub = torch.tensor([0.4196, 0.4196]) # Hubbard U values of H, H
         >>> cutoff = _expgamma_cutoff(ua * 3.2, ub * 3.2,
-                                      torch.zeros_like(ua))
-
-        # Cutoff distances for C-H and H-H in a.u.
+        ...                           torch.zeros_like(ua))
+        >>> # Cutoff distances for C-H and H-H in a.u.
         >>> print(cutoff)
         tensor([22.0375, 20.0250])
 
@@ -546,16 +542,15 @@ def build_gamma_matrix(
         >>> from tbmalt import OrbitalInfo, Geometry
         >>> from tbmalt.physics.dftb.gamma import build_gamma_matrix
         >>> from ase.build import molecule
-
-        # Preparation of system to calculate
+        >>>
+        >>> # Preparation of system to calculate
         >>> geo = Geometry.from_ase_atoms(molecule('CH4'))
         >>> orbs = OrbitalInfo(geo.atomic_numbers,
-                               shell_dict= {1: [0], 6: [0, 1]})
+        ...                    shell_dict= {1: [0], 6: [0, 1]})
         >>> hubbard_U = torch.tensor([0.3647, 0.4196, 0.4196, 0.4196, 0.4196])
         >>> r = geo.distances
         >>> r[r != 0.0] = 1.0 / r[r != 0.0]
-
-        # Build the gamma matrix
+        >>> # Build the gamma matrix
         >>> gamma = build_gamma_matrix(geo, orbs, r, hubbard_U, 'exponential')
         >>> print(gamma)
         tensor([[0.3647, 0.3234, 0.3234, 0.3234, 0.3234],

--- a/tbmalt/physics/dftb/slaterkoster.py
+++ b/tbmalt/physics/dftb/slaterkoster.py
@@ -35,26 +35,25 @@ def sub_block_rot(l_pair: Tensor, u_vec: Tensor,
     Examples:
         >>> import torch
         >>> from tbmalt.physics.dftb.slaterkoster import sub_block_rot
-
-        # Slater-Koster transformation for single system
+        >>>
+        >>> # Slater-Koster transformation for single system
         >>> l_pair = torch.tensor([0, 0])  # s-s orbital
         >>> u_vecs = torch.tensor([0.7001, 0.6992, 0.1449])
         >>> integrals = torch.tensor([-0.1610])
         >>> pred = sub_block_rot(l_pair, u_vecs, integrals)
         >>> print(pred)
         tensor([[-0.1610]])
-
-        # Slater-Koster transformation for batch system
+        >>> # Slater-Koster transformation for batch system
         >>> l_pair = torch.tensor([0, 1])  # s-p orbital
         >>> u_vecs  = torch.tensor([
-        [0.7001, 0.6992, 0.1449], [0.8199, 0.5235, 0.2317],
-        [0.1408, 0.7220, 0.6774], [0.5945, 0.6138, 0.5195],
-        [0.5749, 0.6112, 0.5440], [0.4976, 0.5884, 0.6374],
-        [0.0075, 0.5677, 0.8232], [0.7632, 0.4264, 0.4856],
-        [0.3923, 0.3178, 0.8632], [0.0278, 0.6896, 0.7237]])
+        ...     [0.7001, 0.6992, 0.1449], [0.8199, 0.5235, 0.2317],
+        ...     [0.1408, 0.7220, 0.6774], [0.5945, 0.6138, 0.5195],
+        ...     [0.5749, 0.6112, 0.5440], [0.4976, 0.5884, 0.6374],
+        ...     [0.0075, 0.5677, 0.8232], [0.7632, 0.4264, 0.4856],
+        ...     [0.3923, 0.3178, 0.8632], [0.0278, 0.6896, 0.7237]])
         >>> integrals = torch.tensor([
-        [-0.1011], [-0.1011], [-0.1011], [-0.1011], [-0.1011],
-        [-0.1011], [-0.1011], [-0.1011], [-0.1011], [-0.1011]])
+        ...     [-0.1011], [-0.1011], [-0.1011], [-0.1011], [-0.1011],
+        ...     [-0.1011], [-0.1011], [-0.1011], [-0.1011], [-0.1011]])
         >>> pred = sub_block_rot(l_pair, u_vecs, integrals)
         >>> print(pred)
         tensor([[[-0.0707, -0.0146, -0.0708]],

--- a/tbmalt/structures/periodicity.py
+++ b/tbmalt/structures/periodicity.py
@@ -5,6 +5,7 @@ This module implement cell translation for 1D & 2D & 3D periodic
 boundary conditions. Distance matrix and position vectors for pbc
 will be constructed.
 """
+from __future__ import annotations
 from typing import Union, Optional
 from abc import ABC, abstractmethod
 import torch
@@ -12,6 +13,11 @@ from torch import Tensor
 import numpy as np
 from tbmalt.common.batch import pack, bT
 from tbmalt.common import cached_property
+
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from tbmalt.structures.geometry import Geometry
 
 
 class Periodicity(ABC):
@@ -61,7 +67,7 @@ class Periodicity(ABC):
 
     """
     def __init__(
-            self, geometry: "Geometry", cutoff: Union[Tensor, float]):
+            self, geometry: Geometry, cutoff: Union[Tensor, float]):
 
         cutoff = self._check(geometry.lattice, cutoff)
 
@@ -454,7 +460,7 @@ class Triclinic(Periodicity):
 
     """
 
-    def __init__(self, geometry: "Geometry", cutoff: Union[Tensor, float]):
+    def __init__(self, geometry: Geometry, cutoff: Union[Tensor, float]):
         super().__init__(geometry, cutoff)
 
     @property

--- a/tbmalt/tools/__init__.py
+++ b/tbmalt/tools/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""A collection of miscellaneous helper modules.
+
+Modules that are not linked to any specific component of the codebase, yet are
+not employed so extensively as to justify inclusion in the ``common`` module,
+are placed here, within the ``tools`` module.
+"""


### PR DESCRIPTION
This fixes a issue with the documentation build system as well as fixing some other minor documentation related issues. This acts as the final cleanup pass of the documentation before pushing the development branch to main.

Note that this pull request also fixes the `Dftb2converged` attribute which broke several commits ago.

There are some thing things left to resolve namely, i) being able to separate attributes and properties before passing them off to the sphinx auto-doc system, ii) defining the types of each attribute, and iii) adding module-level doc-strings to every file. However, these can be put off for the moment as they are not critical.