### PR TITLE
fix: added gradient support to `fermi_search`

### DIFF
--- a/tbmalt/common/maths/__init__.py
+++ b/tbmalt/common/maths/__init__.py
@@ -305,7 +305,7 @@ class _SymEigB(torch.autograd.Function):
         and eigenvectors were taken.
 
         Arguments:
-            w_bar: Gradients associated with the the eigenvalues.
+            w_bar: Gradients associated with the eigenvalues.
             v_bar: Gradients associated with the eigenvectors.
 
         Returns:

--- a/tests/unittests/test_dftb_forces.py
+++ b/tests/unittests/test_dftb_forces.py
@@ -25,21 +25,26 @@ def molecules(device) -> List[Geometry]:
     Returns:
         geometries: A list of `Geometry` objects.
     """
-    H2 = Geometry(torch.tensor([1, 1], device=device),
-                  torch.tensor([
-                      [+0.00, +0.00, +0.37],
-                      [+0.00, +0.00, -0.37]],
-                      requires_grad=True,
-                      device=device),
-                  units='angstrom')
+    H2 = Geometry(
+        torch.tensor([1, 1], device=device),
+        torch.tensor([
+            [+0.00, +0.00, +0.37],
+            [+0.00, +0.00, -0.37]],
+            requires_grad=True,
+            device=device),
+            units='angstrom')
 
-    H2O = Geometry(torch.tensor([8, 1, 1], device=device),
-               torch.tensor([[0.0, 0.0, 0.0],
-                             [0.0, 0.8, -0.5],
-                             [0.0, -0.8, -0.5]],
-                            requires_grad=True,
-                            device=device),
-               units='angstrom')
+    H2O = Geometry(
+        torch.tensor([8, 1, 1], device=device),
+        torch.tensor([
+            [0.0, 0.0, 0.0],
+            [0.0, 0.8, -0.5],
+            [0.0, -0.8, -0.5]],
+            requires_grad=True,
+            device=device),
+            units='angstrom')
+
+
     return [H2, H2O]
 
 species = [1, 8]


### PR DESCRIPTION
Refactored the `fermi_search` function to add support for gradients. Previously, non-trivial gradients errors would occur when operating on systems with partial occupancies. Unit tests were also expanded to better cover systems with fractional occupancies.