### PR TITLE
fix: resolved several shape related bugs

### DIFF
--- a/tbmalt/physics/dftb/gamma.py
+++ b/tbmalt/physics/dftb/gamma.py
@@ -124,14 +124,15 @@ def gamma_exponential(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor
     gamma[..., ut[0], ut[1]] = gamma_tr
     gamma[..., ut[1], ut[0]] = gamma[..., ut[0], ut[1]]
 
-    gamma = gamma.squeeze()
+    # Ensure any unnecessary dimensions are removed
+    gamma = gamma.reshape(orbs.res_matrix_shape)
 
     # Subtract the gamma matrix from the inverse distance to get the final
     # result.
     r[r != 0.0] = 1.0 / r[r != 0.0]
     gamma = r - gamma
 
-    return gamma.squeeze()
+    return gamma
 
 
 def gamma_gaussian(geometry: Geometry, orbs: OrbitalInfo, hubbard_Us: Tensor

--- a/tbmalt/structures/orbitalinfo.py
+++ b/tbmalt/structures/orbitalinfo.py
@@ -214,7 +214,7 @@ class OrbitalInfo:
     @property
     def shells_per_atom(self) -> Tensor:
         """Returns the number of shells associated with each atom."""
-        return self._shells_per_species[self.atomic_numbers.view(-1)
+        return self._shells_per_species[self.atomic_numbers.reshape(-1)
                                         ].view_as(self.atomic_numbers)
 
     def to(self, device: device) -> 'OrbitalInfo':
@@ -562,7 +562,7 @@ class OrbitalInfo:
             an_mat = self.atomic_numbers.gather(-1, indices)
 
         elif form == 'shell':
-            an = self.atomic_numbers.view(-1)
+            an = self.atomic_numbers.reshape(-1)
             an_mat = an.repeat_interleave(self._shells_per_species[an])
             if batch:
                 an_mat = pack(split_by_size(an_mat, self.n_shells), value=0)
@@ -610,7 +610,7 @@ class OrbitalInfo:
         elif form == 'shell':
             i_mat = arange(
                 self.n_atoms.max(), device=self.__device).expand_as(
-                ans).repeat_interleave(self._shells_per_species[ans.view(-1)])
+                ans).repeat_interleave(self._shells_per_species[ans.reshape(-1)])
 
             if self.atomic_numbers.dim() == 2:  # "if batch"
                 i_mat = pack(split_by_size(i_mat, self.n_shells), value=-1)

--- a/tests/unittests/test_dftb.py
+++ b/tests/unittests/test_dftb.py
@@ -877,6 +877,17 @@ def merge_systems(device, *systems):
 
     results = {k: pack(v) for k, v in results.items()}
 
+    # Catch to ensure a single system is treated as a batch of size one
+    if len(systems) == 1:
+        geometry = geometry.unsqueeze()
+
+        orbs = OrbitalInfo(
+            orbs.atomic_numbers.unsqueeze(0),
+            orbs.shell_dict, orbs.shell_resolved)
+
+        results = {k: v.unsqueeze(0) for k, v in results.items()}
+
+
     return geometry, orbs, results, kwargs
 
 
@@ -902,6 +913,16 @@ def merge_systems_shell_resolved(device, *systems):
             results[k].append(t_results[k])
 
     results = {k: pack(v) for k, v in results.items()}
+
+    # Catch to ensure a single system is treated as a batch of size one
+    if len(systems) == 1:
+        geometry = geometry.unsqueeze()
+
+        orbs = OrbitalInfo(
+            orbs.atomic_numbers.unsqueeze(0),
+            orbs.shell_dict, orbs.shell_resolved)
+
+        results = {k: v.unsqueeze(0) for k, v in results.items()}
 
     return geometry, orbs, results, kwargs
 
@@ -996,6 +1017,8 @@ def dftb1_helper(calculator, geometry, orbs, results):
         if isinstance(predicted, torch.Tensor):
             device_check = predicted.device == calculator.device
             assert device_check, f'Attribute {i} was returned on the wrong device'
+            shape_check = predicted.device == calculator.device
+            assert shape_check, f'Attribute {i} was the wrong shape'
 
 
     check_allclose('q_final')
@@ -1042,6 +1065,8 @@ def dftb2_helper(calculator, geometry, orbs, results):
         if isinstance(predicted, torch.Tensor):
             device_check = predicted.device == calculator.device
             assert device_check, f'Attribute {i} was returned on the wrong device'
+            shape_check = predicted.device == calculator.device
+            assert shape_check, f'Attribute {i} was the wrong shape'
 
     check_allclose('q_final_atomic', True)
     check_allclose('band_energy')

--- a/tests/unittests/test_dftb_periodic.py
+++ b/tests/unittests/test_dftb_periodic.py
@@ -742,6 +742,16 @@ def merge_systems(device, *systems):
 
     results = {k: pack(v) for k, v in results.items()}
 
+    # Catch to ensure a single system is treated as a batch of size one
+    if len(systems) == 1:
+        geometry = geometry.unsqueeze()
+
+        orbs = OrbitalInfo(
+            orbs.atomic_numbers.unsqueeze(0),
+            orbs.shell_dict, orbs.shell_resolved)
+
+        results = {k: v.unsqueeze(0) for k, v in results.items()}
+
     return geometry, orbs, results, kwargs
 
 
@@ -763,6 +773,8 @@ def dftb1_helper(calculator, geometry, orbs, results):
         if isinstance(predicted, torch.Tensor):
             device_check = predicted.device == calculator.device
             assert device_check, f'Attribute {i} was returned on the wrong device'
+            shape_check = predicted.device == calculator.device
+            assert shape_check, f'Attribute {i} was the wrong shape'
 
     check_allclose('q_final_atomic')
 
@@ -785,6 +797,8 @@ def dftb2_helper(calculator, geometry, orbs, results):
         if isinstance(predicted, torch.Tensor):
             device_check = predicted.device == calculator.device
             assert device_check, f'Attribute {i} was returned on the wrong device'
+            shape_check = predicted.device == calculator.device
+            assert shape_check, f'Attribute {i} was the wrong shape'
 
     check_allclose('q_final_atomic')
     check_allclose('band_energy')

--- a/tests/unittests/test_gamma.py
+++ b/tests/unittests/test_gamma.py
@@ -400,6 +400,16 @@ def merge_systems(device, *systems):
 
     results = {k: pack(v) for k, v in results.items()}
 
+    # Catch to ensure a single system is treated as a batch of size one
+    if len(systems) == 1:
+        geometry = geometry.unsqueeze()
+
+        orbs = OrbitalInfo(
+            orbs.atomic_numbers.unsqueeze(0),
+            orbs.shell_dict, orbs.shell_resolved)
+
+        results = {k: v.unsqueeze(0) for k, v in results.items()}
+
     return geometry, orbs, results
 
 


### PR DESCRIPTION
Replaced several `torch.view` calls with their `torch.reshape` counterparts. This allows PyTorch to make a copy of a tensor instead of a view when it encounters a non-contiguous tensor rather than raising an exception.

The replaced `torch.unsqueeze` with a `torch.reshape` operation in the `gamma_exponential` method to avoid unintentionally striping the batch dimension from batches of size one.

Fixed the `merge_systems` helper function within several unit tests so that it correctly returns a batch of size one when invoked on a single system. Added a new method `Geometry.unsqueeze()` to allow for single system `Geometry` instances to be easily converted into batches of size one.